### PR TITLE
Update Markdown rendering to look better on GitHub

### DIFF
--- a/src/renderSchema.js
+++ b/src/renderSchema.js
@@ -7,15 +7,20 @@ const marked = require('marked')
 // an HTML tag. So in some places (like descriptions of the types themselves) we
 // just output the raw description. In other places, like table cells, we need
 // to output pre-rendered Markdown, otherwise GitHub won't interpret it.
-marked.setOptions({
-  breaks: false
-})
+marked.setOptions({ gfm: true })
 
 function markdown (markup) {
-  return marked(markup || '')
-    .replace(/<\/p>\s*<p>/g, '<br><br>')
-    .replace(/<\/?p>/g, '')
+  let output = marked(markup || '')
+    // Join lines, unless the next line starts with a tag.
+    .replace(/\n(?!<)/g, ' ')
+    // Wrap after 80 characters.
+    .replace(/([^\n]{80,}?) /g, '$1\n')
     .trim()
+  // If there's only one paragraph, unwrap it.
+  if (output.lastIndexOf('<p>') === 0 && output.endsWith('</p>')) {
+    output = output.slice(3, -4)
+  }
+  return output
 }
 
 function sortBy (arr, property) {


### PR DESCRIPTION
This makes a few improvements to both the literal and rendered output:

* GitHub seems to have changed their `<p>` styling to be less disruptive within a table cell. Previously, paragraphs would have too much margin/padding around them, misaligning them with content in other (non-paragraph) cells. Now, paragraph content aligns with non-paragraph content.
  * To fix this, previously `graphql-markdown` removed all `<p>` tags and ensured multiple paragraphs were separated with `<br>` elements.
  * Now, `graphql-markdown` still removes `<p>` tags if the entire string is a single paragraph (to minimize their presence in the output). However, if there are multiple paragraphs, or elements before/after the only paragraph, they will be maintained. This improves the rendering of cases such as lists (and various other non-paragraph elements) following paragraphs.
* The `marked` renderer is now called with `{ gfm: true }`.
* The literal output of the rendered schema Markdown is now reformatted to wrap after 80 characters instead of maintaining the original source's line wrapping. This looks better because the original content was written in the context of its surrounding code and indentation level, so maintaining the original wrapping just looked wrong. This has no affect on the rendered output, just the literal output.