### PR TITLE
Remove pre-rendering based on updated GitHub parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,10 @@ Options:
 
 ## Output
 
-Output is optimized for display on GitHub, using GitHub's Markdown renderer.
+Output is optimized for display on GitHub, using GitHub Flavored Markdown.
 
-Due to the complexity of the tables in the generated document, much of the
-output is HTML (as allowed by Markdown). Some of your GraphQL descriptions may
-be printed as-is (for GitHub to render) while others are pre-rendered by
-`graphql-markdown` (if they need to be included in certain HTML tags – GitHub
-will not render such content as Markdown).
+Due to the complexity of the tables in the generated document, much of the table
+output is HTML (as allowed by Markdown).
 
 
 [example]: https://github.com/exogen/graphbrainz/blob/master/docs/types.md

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "pre-commit": "lint",
   "dependencies": {
     "graphql": "^0.9.1",
-    "marked": "^0.3.6",
     "minimist": "^1.2.0",
     "node-fetch": "^1.6.3",
     "pre-commit": "^1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -735,10 +735,6 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.1"
     yallist "^2.0.0"
 
-marked@^0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
-
 minimatch@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"


### PR DESCRIPTION
With GitHub's update to GitHub Flavored Markdown, it is no longer necessary to pre-render Markdown content in table cells, as long as there are blank lines surrounding the content.

While not as pretty due to the descriptions being wrapped in `<p>` tags (adding bottom padding to even single-line table cells), this significantly simplifies the approach and the output.

Fixes #3.