### PR TITLE
Allow `renderSchema` to use a custom "printer"

### DIFF
--- a/src/renderSchema.js
+++ b/src/renderSchema.js
@@ -88,7 +88,7 @@ function renderSchema (schema, options) {
   const title = options.title || 'Schema Types'
   const prologue = options.prologue || ''
   const epilogue = options.epilogue || ''
-  const printer = console.log
+  const printer = options.printer || console.log
 
   if (schema.__schema) {
     schema = schema.__schema


### PR DESCRIPTION
Hi there!

Hope you don't mind me submitting this request out of the blue, but I saw that `renderSchema` had `console.log` hardcoded as the "printer", so this change lets you specify a custom printer.

I'm using `graphql-markdown` as a module in an AWS Lambda function and want to be able to do something with the resulting Markdown. Here's a working example:

```js
// const graphqlMarkdown = require('graphql-markdown')
const graphqlMarkdown = require('./')

graphqlMarkdown.loadSchemaJSON('https://spotify-graphql-server.herokuapp.com/graphql').then(function (schema) {
  const markdownArray = []

  graphqlMarkdown.renderSchema(schema, {
    title: 'Spotify GraphQL API',
    printer: function (str) {
      markdownArray.push(str)
    }
  })

  // Now you can do something with the resulting Markdown, like using the
  // GitHub API to create/update a file.
  const markdownAsBase64 = Buffer.from(markdownArray.join('\n')).toString('base64')
  console.log(markdownAsBase64)
}).catch(function (e) { console.error(e) })
```

Let me know what you think!