### PR TITLE
Add diffSchema function, document Node API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ $ npm install graphql-markdown --save-dev
 
 ## Usage
 
+### Command Line API
+
 Installing the package adds a `graphql-markdown` script. Point it at a schema
 and the output will be written to stdout.
 
@@ -40,7 +42,7 @@ $ graphql-markdown ./path/to/schema.graphql > schema.md
 $ graphql-markdown ./path/to/schema.json > schema.md
 ```
 
-### Options
+#### Options
 
 ```console
 $ graphql-markdown --help
@@ -64,6 +66,39 @@ Options:
                          module first (useful for e.g. babel-register)
   --version              Print version and exit
 ```
+
+### Node API
+
+The following functions are exported from the `graphql-markdown` module for
+programmatic use.
+
+#### loadSchemaJSON(schemaPath: string)
+
+Given a string pointing to a GraphQL schema (URL, module, or file path), get the
+result of the introspection query, suitable for use as input to `renderSchema`.
+
+#### renderSchema(schema: object, options: object)
+
+Given a schema JSON object (the output of the introspection query, an object
+with a `__schema` property), render the schema to a string.
+
+| Option     | Description |
+| ---------- | ----------- |
+| `title`    | The title of the document, defaults to “Schema Types”. |
+| `prologue` | Markdown content to include after the title. |
+| `epilogue` | Markdown content to include at the end of the document. |
+| `printer`  | A function to handle each line of output, defaults to `console.log`. |
+
+#### diffSchema(oldSchema: object, newSchema: object, options: object)
+
+Given two schema JSON objects (the results of the introspection query on two
+schemas), return a new schema JSON object containing only the added or updated
+types and fields. You can use this to document a schema update, or to document
+the effects of a schema extension (e.g. `extend type` definitions).
+
+| Option            | Description |
+| ----------------- | ----------- |
+| `processTypeDiff` | A function to add or modify fields on each type that will be output. |
 
 ## Output
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lint"
   ],
   "dependencies": {
+    "deep-diff": "^0.3.8",
     "graphql": "^0.11.7",
     "minimist": "^1.2.0",
     "node-fetch": "^1.7.1",

--- a/src/diffSchema.js
+++ b/src/diffSchema.js
@@ -1,0 +1,103 @@
+'use strict'
+const diff = require('deep-diff')
+
+function toNamedObject (arr, modifier = obj => obj) {
+  if (!arr) {
+    return {}
+  }
+  return arr.reduce((obj, value) => {
+    obj[value.name] = modifier(value)
+    return obj
+  }, {})
+}
+
+function toNamedArray (obj, modifier = obj => obj) {
+  if (!obj) {
+    return []
+  }
+  return Object.entries(obj).map(([key, value]) => {
+    return modifier(Object.assign({}, value, { name: key }))
+  })
+}
+
+function toDiffableSchema (schema) {
+  const types = toNamedObject(schema.__schema.types, type => {
+    if (type.fields) {
+      type = Object.assign({}, type, {
+        fields: toNamedObject(type.fields)
+      })
+    }
+    if (type.enumValues) {
+      type = Object.assign({}, type, {
+        enumValues: toNamedObject(type.enumValues)
+      })
+    }
+    return type
+  })
+
+  const directives = toNamedObject(schema.__schema.directives)
+
+  return Object.assign({}, schema, {
+    __schema: Object.assign({}, schema.__schema, {
+      types,
+      directives
+    })
+  })
+}
+
+function fromDiffableSchema (schema) {
+  const types = toNamedArray(schema.__schema.types, type => {
+    if (type.fields) {
+      type = Object.assign({}, type, {
+        fields: toNamedArray(type.fields)
+      })
+    }
+    if (type.enumValues) {
+      type = Object.assign({}, type, {
+        enumValues: toNamedArray(type.enumValues)
+      })
+    }
+    return type
+  })
+
+  const directives = toNamedArray(schema.__schema.directives)
+
+  return Object.assign({}, schema, {
+    __schema: Object.assign({}, schema.__schema, {
+      types,
+      directives
+    })
+  })
+}
+
+function diffSchema (oldSchema, newSchema, options) {
+  const oldDiffableSchema = toDiffableSchema(oldSchema)
+  const newDiffableSchema = toDiffableSchema(newSchema)
+  const changes = diff(oldDiffableSchema, newDiffableSchema)
+  const diffSchema = changes.reduce((schema, change) => {
+    diff.applyChange(schema, newDiffableSchema, change)
+    return schema
+  }, {})
+  const schema = fromDiffableSchema(diffSchema)
+  const newTypes = newDiffableSchema.__schema.types
+  schema.__schema.types = schema.__schema.types.map(type => {
+    if (options.processTypeDiff) {
+      type = options.processTypeDiff(type)
+    }
+    type = Object.assign({}, newTypes[type.name], type)
+    if (type.fields) {
+      const newFields = newTypes[type.name].fields
+      type.fields = type.fields.map(field => newFields[field.name])
+    }
+    if (type.enumValues) {
+      const newEnumValues = newTypes[type.name].enumValues
+      type.enumValues = type.enumValues.map(
+        enumValue => newEnumValues[enumValue.name]
+      )
+    }
+    return type
+  })
+  return schema
+}
+
+module.exports = diffSchema

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const parseArgs = require('minimist')
 const resolveFrom = require('resolve-from')
 const loadSchemaJSON = require('./loadSchemaJSON')
 const renderSchema = require('./renderSchema')
+const diffSchema = require('./diffSchema')
 
 function safeExit (code) {
   process.on('exit', function () {
@@ -63,4 +64,8 @@ if (require.main === module) {
   }
 }
 
-module.exports = { loadSchemaJSON, renderSchema }
+module.exports = {
+  loadSchemaJSON,
+  renderSchema,
+  diffSchema
+}

--- a/src/renderSchema.js
+++ b/src/renderSchema.js
@@ -100,7 +100,9 @@ function renderSchema (schema, options) {
 
   const types = schema.types.filter(type => !type.name.startsWith('__'))
 
-  const query = types.filter(type => type.name === schema.queryType.name)[0]
+  const queryType = schema.queryType
+  const query =
+    queryType && types.find(type => type.name === schema.queryType.name)
   const objects = types.filter(type => type.kind === 'OBJECT' && type !== query)
   const enums = types.filter(type => type.kind === 'ENUM')
   const scalars = types.filter(type => type.kind === 'SCALAR')
@@ -119,83 +121,105 @@ function renderSchema (schema, options) {
 
   printer('<details>')
   printer('  <summary><strong>Table of Contents</strong></summary>\n')
-  printer('  * [Query](#query)')
-  printer('  * [Objects](#objects)')
-  objects.forEach(type => {
-    printer(`    * [${type.name}](#${type.name.toLowerCase()})`)
-  })
-  printer('  * [Enums](#enums)')
-  enums.forEach(type => {
-    printer(`    * [${type.name}](#${type.name.toLowerCase()})`)
-  })
-  printer('  * [Scalars](#scalars)')
-  scalars.forEach(type => {
-    printer(`    * [${type.name}](#${type.name.toLowerCase()})`)
-  })
-  printer('  * [Interfaces](#interfaces)')
-  interfaces.forEach(type => {
-    printer(`    * [${type.name}](#${type.name.toLowerCase()})`)
-  })
+  if (query) {
+    printer('  * [Query](#query)')
+  }
+  if (objects.length) {
+    printer('  * [Objects](#objects)')
+    objects.forEach(type => {
+      printer(`    * [${type.name}](#${type.name.toLowerCase()})`)
+    })
+  }
+  if (enums.length) {
+    printer('  * [Enums](#enums)')
+    enums.forEach(type => {
+      printer(`    * [${type.name}](#${type.name.toLowerCase()})`)
+    })
+  }
+  if (scalars.length) {
+    printer('  * [Scalars](#scalars)')
+    scalars.forEach(type => {
+      printer(`    * [${type.name}](#${type.name.toLowerCase()})`)
+    })
+  }
+  if (interfaces.length) {
+    printer('  * [Interfaces](#interfaces)')
+    interfaces.forEach(type => {
+      printer(`    * [${type.name}](#${type.name.toLowerCase()})`)
+    })
+  }
   printer('\n</details>')
 
-  printer(`\n## Query ${query.name === 'Query' ? '' : '(' + query.name + ')'}`)
-  renderObject(query, { skipTitle: true, printer })
+  if (query) {
+    printer(
+      `\n## Query ${query.name === 'Query' ? '' : '(' + query.name + ')'}`
+    )
+    renderObject(query, { skipTitle: true, printer })
+  }
 
-  printer('\n## Objects')
-  objects.forEach(type => renderObject(type, { printer }))
+  if (objects.length) {
+    printer('\n## Objects')
+    objects.forEach(type => renderObject(type, { printer }))
+  }
 
-  printer('\n## Enums')
-  enums.forEach(type => {
-    printer(`\n### ${type.name}\n`)
-    if (type.description) {
-      printer(`${type.description}\n`)
-    }
-    printer('<table>')
-    printer('<thead>')
-    printer('<th align="left">Value</th>')
-    printer('<th align="left">Description</th>')
-    printer('</thead>')
-    printer('<tbody>')
-    type.enumValues.forEach(value => {
-      printer('<tr>')
-      printer(
-        `<td valign="top"><strong>${value.name}</strong>${value.isDeprecated
-          ? ' ⚠️'
-          : ''}</td>`
-      )
-      if (value.description || value.isDeprecated) {
-        printer('<td>')
-        if (value.description) {
-          printer(`\n${value.description}\n`)
-        }
-        if (value.isDeprecated) {
-          printer('<p>⚠️ <strong>DEPRECATED</strong></p>')
-          if (value.deprecationReason) {
-            printer('<blockquote>')
-            printer(`\n${value.deprecationReason}\n`)
-            printer('</blockquote>')
-          }
-        }
-        printer('</td>')
-      } else {
-        printer('<td></td>')
+  if (enums.length) {
+    printer('\n## Enums')
+    enums.forEach(type => {
+      printer(`\n### ${type.name}\n`)
+      if (type.description) {
+        printer(`${type.description}\n`)
       }
-      printer('</tr>')
+      printer('<table>')
+      printer('<thead>')
+      printer('<th align="left">Value</th>')
+      printer('<th align="left">Description</th>')
+      printer('</thead>')
+      printer('<tbody>')
+      type.enumValues.forEach(value => {
+        printer('<tr>')
+        printer(
+          `<td valign="top"><strong>${value.name}</strong>${value.isDeprecated
+            ? ' ⚠️'
+            : ''}</td>`
+        )
+        if (value.description || value.isDeprecated) {
+          printer('<td>')
+          if (value.description) {
+            printer(`\n${value.description}\n`)
+          }
+          if (value.isDeprecated) {
+            printer('<p>⚠️ <strong>DEPRECATED</strong></p>')
+            if (value.deprecationReason) {
+              printer('<blockquote>')
+              printer(`\n${value.deprecationReason}\n`)
+              printer('</blockquote>')
+            }
+          }
+          printer('</td>')
+        } else {
+          printer('<td></td>')
+        }
+        printer('</tr>')
+      })
+      printer('</tbody>')
+      printer('</table>')
     })
-    printer('</tbody>')
-    printer('</table>')
-  })
+  }
 
-  printer('\n## Scalars\n')
-  scalars.forEach(type => {
-    printer(`### ${type.name}\n`)
-    if (type.description) {
-      printer(`${type.description}\n`)
-    }
-  })
+  if (scalars.length) {
+    printer('\n## Scalars\n')
+    scalars.forEach(type => {
+      printer(`### ${type.name}\n`)
+      if (type.description) {
+        printer(`${type.description}\n`)
+      }
+    })
+  }
 
-  printer('\n## Interfaces\n')
-  interfaces.forEach(type => renderObject(type, { printer }))
+  if (interfaces.length) {
+    printer('\n## Interfaces\n')
+    interfaces.forEach(type => renderObject(type, { printer }))
+  }
 
   if (epilogue) {
     printer(`\n${epilogue}`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,6 +1131,10 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+deep-diff@^0.3.8:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
+
 deep-equal@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"


### PR DESCRIPTION
* If a document doesn't define a query type, objects, enums, scalars, or interfaces, the respective section will be excluded from the document and table of contents (instead of printing an empty section).
* A new function `diffSchema` can be used to generate a schema containing only the added and update types and fields.
* Document the programmatic Node API in the README.