### PR TITLE
Add an unknownTypeURL option to link to types in other documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,17 @@ result of the introspection query, suitable for use as input to `renderSchema`.
 Given a schema JSON object (the output of the introspection query, an object
 with a `__schema` property), render the schema to a string.
 
-| Option     | Description |
-| ---------- | ----------- |
-| `title`    | The title of the document, defaults to “Schema Types”. |
-| `prologue` | Markdown content to include after the title. |
-| `epilogue` | Markdown content to include at the end of the document. |
-| `printer`  | A function to handle each line of output, defaults to `console.log`. |
+##### Options
+
+* **`title`**: The title of the document, defaults to “Schema Types”.
+* **`prologue`**: Markdown content to include after the title.
+* **`epilogue`**: Markdown content to include at the end of the document.
+* **`printer`**: A function to handle each line of output, defaults to `console.log`.
+* **`unknownTypeURL`**: A string or function to determine the URL for linking to
+  types that aren’t found in the schema being rendered. This may be the case if
+  you’re rendering the result of `diffSchema()`, for example. String values will
+  have `#${type.name.toLowerCase()}` appended, and function values will be
+  called with the type object for full control.
 
 #### diffSchema(oldSchema: object, newSchema: object, options: object)
 
@@ -96,9 +101,10 @@ schemas), return a new schema JSON object containing only the added or updated
 types and fields. You can use this to document a schema update, or to document
 the effects of a schema extension (e.g. `extend type` definitions).
 
-| Option            | Description |
-| ----------------- | ----------- |
-| `processTypeDiff` | A function to add or modify fields on each type that will be output. |
+##### Options
+
+* **`processTypeDiff`**: A function to add or modify fields on each type that
+  will be output.
 
 ## Output
 


### PR DESCRIPTION
If types are split into multiple documents, this will let you point type links to the right document.