### PR TITLE
Introduce header argument

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,8 +66,8 @@ function run(
     }
     const schemaPath = args._[0]
     const headers = [].concat(args['header'] || []).reduce((obj, header) => {
-      const [key, value] = String(header).split('=', 2)
-      obj[key] = value
+      const [key, ...value] = String(header).split('=')
+      obj[key] = value.join('=')
       return obj
     }, {})
     const loadOptions = { headers }

--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,8 @@ function printHelp(console) {
                            create (if the file does not exist)
     --require <module>     If importing the schema from a module, require the specified
                            module first (useful for e.g. babel-register)
+    --header <name=value>  Additional header(s) to use in GraphQL request
+                           e.g. --header "Authorization=Bearer ey..."
     --version              Print version and exit
 `)
 }
@@ -63,7 +65,13 @@ function run(
       }
     }
     const schemaPath = args._[0]
-    loadSchemaJSON(schemaPath).then(schema => {
+    const headers = [].concat(args['header'] || []).reduce((obj, header) => {
+      const [key, value] = String(header).split('=', 2)
+      obj[key] = value
+      return obj
+    }, {})
+    const loadOptions = { headers }
+    loadSchemaJSON(schemaPath, loadOptions).then(schema => {
       const options = {
         title: args.title,
         skipTitle: false,

--- a/src/loadSchemaJSON.js
+++ b/src/loadSchemaJSON.js
@@ -32,7 +32,8 @@ function fetchSchemaJSON(url, options) {
     method: 'POST',
     headers: {
       Accept: 'application/json',
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      ...options.headers
     },
     body: JSON.stringify({ query: graphql.introspectionQuery })
   })
@@ -90,9 +91,9 @@ async function requireSchema(schemaPath) {
   )
 }
 
-function loadSchemaJSON(schemaPath) {
+function loadSchemaJSON(schemaPath, loadOptions) {
   if (schemaPath.indexOf('://') >= 0) {
-    return fetchSchemaJSON(schemaPath)
+    return fetchSchemaJSON(schemaPath, loadOptions)
   } else if (schemaPath.match(/\.g(raph)?ql$/)) {
     return parseSchemaGraphQL(schemaPath).then(schemaToJSON)
   }

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -477,6 +477,8 @@ Object {
                            create (if the file does not exist)
     --require <module>     If importing the schema from a module, require the specified
                            module first (useful for e.g. babel-register)
+    --header <name=value>  Additional header(s) to use in GraphQL request
+                           e.g. --header \\"Authorization=Bearer ey...\\"
     --version              Print version and exit
 
 ",
@@ -510,6 +512,8 @@ Object {
                            create (if the file does not exist)
     --require <module>     If importing the schema from a module, require the specified
                            module first (useful for e.g. babel-register)
+    --header <name=value>  Additional header(s) to use in GraphQL request
+                           e.g. --header \\"Authorization=Bearer ey...\\"
     --version              Print version and exit
 
 ",


### PR DESCRIPTION
Please consider this PR. It introduces an extra `--header <name=value>` argument similar to #36 (but more minimal changes). It can be given multiple times.