### PR TITLE
Fixing issue where newline cause errors in Markdown files while rende…

### DIFF
--- a/src/renderSchema.js
+++ b/src/renderSchema.js
@@ -61,13 +61,13 @@ function renderObject(type, options) {
     if (field.description || field.isDeprecated) {
       printer('<td>')
       if (field.description) {
-        printer(`\n${field.description}\n`)
+        printer(`${field.description}`)
       }
       if (field.isDeprecated) {
         printer('<p>⚠️ <strong>DEPRECATED</strong></p>')
         if (field.deprecationReason) {
           printer('<blockquote>')
-          printer(`\n${field.deprecationReason}\n`)
+          printer(`${field.deprecationReason}`)
           printer('</blockquote>')
         }
       }
@@ -83,7 +83,7 @@ function renderObject(type, options) {
         printer(`<td valign="top">${renderType(arg.type, { getTypeURL })}</td>`)
         if (arg.description) {
           printer('<td>')
-          printer(`\n${arg.description}\n`)
+          printer(`${arg.description}`)
           printer('</td>')
         } else {
           printer(`<td></td>`)
@@ -256,13 +256,13 @@ function renderSchema(schema, options) {
         if (value.description || value.isDeprecated) {
           printer('<td>')
           if (value.description) {
-            printer(`\n${value.description}\n`)
+            printer(`${value.description}`)
           }
           if (value.isDeprecated) {
             printer('<p>⚠️ <strong>DEPRECATED</strong></p>')
             if (value.deprecationReason) {
               printer('<blockquote>')
-              printer(`\n${value.deprecationReason}\n`)
+              printer(`${value.deprecationReason}`)
               printer('</blockquote>')
             }
           }

--- a/test/fixtures/cover-art-archive.md
+++ b/test/fixtures/cover-art-archive.md
@@ -34,82 +34,64 @@ An individual piece of album artwork from the [Cover Art Archive](https://musicb
 <td colspan="2" valign="top"><strong>fileID</strong></td>
 <td valign="top">String!</td>
 <td>
-
 The Internet Archive’s internal file ID for the image.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>image</strong></td>
 <td valign="top">URLString!</td>
 <td>
-
 The URL at which the image can be found.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>thumbnails</strong></td>
 <td valign="top"><a href="#coverartarchiveimagethumbnails">CoverArtArchiveImageThumbnails</a>!</td>
 <td>
-
 A set of thumbnails for the image.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>front</strong></td>
 <td valign="top">Boolean!</td>
 <td>
-
 Whether this image depicts the “main front” of the release.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>back</strong></td>
 <td valign="top">Boolean!</td>
 <td>
-
 Whether this image depicts the “main back” of the release.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>types</strong></td>
 <td valign="top">[String]!</td>
 <td>
-
 A list of [image types](https://musicbrainz.org/doc/Cover_Art/Types)
 describing what part(s) of the release the image includes.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edit</strong></td>
 <td valign="top">Int</td>
 <td>
-
 The MusicBrainz edit ID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>approved</strong></td>
 <td valign="top">Boolean</td>
 <td>
-
 Whether the image was approved by the MusicBrainz edit system.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>comment</strong></td>
 <td valign="top">String</td>
 <td>
-
 A free-text comment left for the image.
-
 </td>
 </tr>
 </tbody>
@@ -133,20 +115,16 @@ URLs for thumbnails of different sizes for a particular piece of cover art.
 <td colspan="2" valign="top"><strong>small</strong></td>
 <td valign="top">URLString</td>
 <td>
-
 The URL of a small version of the cover art, where the maximum dimension is
 250px.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>large</strong></td>
 <td valign="top">URLString</td>
 <td>
-
 The URL of a large version of the cover art, where the maximum dimension is
 500px.
-
 </td>
 </tr>
 </tbody>
@@ -172,7 +150,6 @@ as well as a summary of what artwork is available.
 <td colspan="2" valign="top"><strong>front</strong></td>
 <td valign="top">URLString</td>
 <td>
-
 The URL of an image depicting the album cover or “main front” of the release,
 i.e. the front of the packaging of the audio recording (or in the case of a
 digital release, the image associated with it in a digital media store).
@@ -181,25 +158,21 @@ In the MusicBrainz schema, this field is a Boolean value indicating the
 presence of a front image, whereas here the value is the URL for the image
 itself if one exists. You can check for null if you just want to determine
 the presence of an image.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">size</td>
 <td valign="top"><a href="#coverartarchiveimagesize">CoverArtArchiveImageSize</a></td>
 <td>
-
 The size of the image to retrieve. By default, the returned image will
 have its full original dimensions, but certain thumbnail sizes may be
 retrieved as well.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>back</strong></td>
 <td valign="top">URLString</td>
 <td>
-
 The URL of an image depicting the “main back” of the release, i.e. the back
 of the packaging of the audio recording.
 
@@ -207,55 +180,44 @@ In the MusicBrainz schema, this field is a Boolean value indicating the
 presence of a back image, whereas here the value is the URL for the image
 itself. You can check for null if you just want to determine the presence of
 an image.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">size</td>
 <td valign="top"><a href="#coverartarchiveimagesize">CoverArtArchiveImageSize</a></td>
 <td>
-
 The size of the image to retrieve. By default, the returned image will
 have its full original dimensions, but certain thumbnail sizes may be
 retrieved as well.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>images</strong></td>
 <td valign="top">[<a href="#coverartarchiveimage">CoverArtArchiveImage</a>]!</td>
 <td>
-
 A list of images depicting the different sides and surfaces of a release’s
 media and packaging.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artwork</strong></td>
 <td valign="top">Boolean!</td>
 <td>
-
 Whether there is artwork present for this release.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>count</strong></td>
 <td valign="top">Int!</td>
 <td>
-
 The number of artwork images present for this release.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>release</strong></td>
 <td valign="top"><a href="#release">Release</a></td>
 <td>
-
 The particular release shown in the returned cover art.
-
 </td>
 </tr>
 </tbody>
@@ -283,11 +245,9 @@ MusicBrainz as one release.
 <td colspan="2" valign="top"><strong>coverArtArchive</strong></td>
 <td valign="top"><a href="#coverartarchiverelease">CoverArtArchiveRelease</a></td>
 <td>
-
 An object containing a list and summary of the cover art images that are
 present for this release from the [Cover Art Archive](https://musicbrainz.org/doc/Cover_Art_Archive).
 This field is provided by the Cover Art Archive extension.
-
 </td>
 </tr>
 </tbody>
@@ -318,13 +278,11 @@ album – it doesn’t matter how many CDs or editions/versions it had.
 <td colspan="2" valign="top"><strong>coverArtArchive</strong></td>
 <td valign="top"><a href="#coverartarchiverelease">CoverArtArchiveRelease</a></td>
 <td>
-
 The cover art for a release in the release group, obtained from the
 [Cover Art Archive](https://musicbrainz.org/doc/Cover_Art_Archive). A
 release in the release group will be chosen as representative of the release
 group.
 This field is provided by the Cover Art Archive extension.
-
 </td>
 </tr>
 </tbody>
@@ -345,25 +303,19 @@ The image sizes that may be requested at the [Cover Art Archive](https://musicbr
 <tr>
 <td valign="top"><strong>SMALL</strong></td>
 <td>
-
 A maximum dimension of 250px.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>LARGE</strong></td>
 <td>
-
 A maximum dimension of 500px.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>FULL</strong></td>
 <td>
-
 The image’s original dimensions, with no maximum.
-
 </td>
 </tr>
 </tbody>

--- a/test/fixtures/graphbrainz-updateSchema-initial.md
+++ b/test/fixtures/graphbrainz-updateSchema-initial.md
@@ -110,45 +110,35 @@ requests can be made.
 <td colspan="2" valign="top"><strong>lookup</strong></td>
 <td valign="top"><a href="#lookupquery">LookupQuery</a></td>
 <td>
-
 Perform a lookup of a MusicBrainz entity by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>browse</strong></td>
 <td valign="top"><a href="#browsequery">BrowseQuery</a></td>
 <td>
-
 Browse all MusicBrainz entities directly linked to another entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>search</strong></td>
 <td valign="top"><a href="#searchquery">SearchQuery</a></td>
 <td>
-
 Search for MusicBrainz entities using Lucene query syntax.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#node">Node</a></td>
 <td>
-
 Fetches an object given its ID
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">id</td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 </tbody>
@@ -176,60 +166,48 @@ entity will be given as a result – even if the actual name wouldn’t be.
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The aliased name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>sortName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The string to use for the purpose of ordering by name (for
 example, by moving articles like ‘the’ to the end or a person’s last name to
 the front).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>locale</strong></td>
 <td valign="top"><a href="#locale">Locale</a></td>
 <td>
-
 The locale (language and/or country) in which the alias is
 used.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>primary</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
-
 Whether this is the main alias for the entity in the
 specified locale (this could mean the most recent or the most common).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The type or purpose of the alias – whether it is a variant,
 search hint, etc.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 </tbody>
@@ -254,106 +232,84 @@ or settlements (countries, cities, or the like).
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>sortName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The string to use for the purpose of ordering by name (for
 example, by moving articles like ‘the’ to the end or a person’s last name to
 the front).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>isoCodes</strong></td>
 <td valign="top">[<a href="#string">String</a>]</td>
 <td>
-
 [ISO 3166 codes](https://en.wikipedia.org/wiki/ISO_3166) are
 the codes assigned by ISO to countries and subdivisions.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">standard</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Specify the particular ISO standard codes to retrieve.
 Available ISO standards are 3166-1, 3166-2, and 3166-3.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The type of area (country, city, etc. – see the [possible
 values](https://musicbrainz.org/doc/Area)).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
-
 A list of artists linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -370,9 +326,7 @@ A list of artists linked to this entity.
 <td colspan="2" valign="top"><strong>events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
-
 A list of events linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -389,9 +343,7 @@ A list of events linked to this entity.
 <td colspan="2" valign="top"><strong>labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
-
 A list of labels linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -408,9 +360,7 @@ A list of labels linked to this entity.
 <td colspan="2" valign="top"><strong>places</strong></td>
 <td valign="top"><a href="#placeconnection">PlaceConnection</a></td>
 <td>
-
 A list of places linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -427,27 +377,21 @@ A list of places linked to this entity.
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 A list of releases linked to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">status</td>
 <td valign="top">[<a href="#releasestatus">ReleaseStatus</a>]</td>
 <td>
-
 Filter by one or more release statuses.
-
 </td>
 </tr>
 <tr>
@@ -464,18 +408,14 @@ Filter by one or more release statuses.
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -492,9 +432,7 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -528,38 +466,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#areaedge">AreaEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#area">Area</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -583,28 +513,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -632,175 +556,139 @@ even a fictional character.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>sortName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The string to use for the purpose of ordering by name (for
 example, by moving articles like ‘the’ to the end or a person’s last name to
 the front).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>country</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The country with which an artist is primarily identified. It
 is often, but not always, its birth/formation country.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
-
 The area with which an artist is primarily identified. It
 is often, but not always, its birth/formation country.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>beginArea</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
-
 The area in which an artist began their career (or where
 they were born, if the artist is a person).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>endArea</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
-
 The area in which an artist ended their career (or where
 they died, if the artist is a person).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>lifeSpan</strong></td>
 <td valign="top"><a href="#lifespan">LifeSpan</a></td>
 <td>
-
 The begin and end dates of the entity’s existence. Its exact
 meaning depends on the type of entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>gender</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Whether a person or character identifies as male, female, or
 neither. Groups do not have genders.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>genderID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `gender`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Whether an artist is a person, a group, or something else.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>ipis</strong></td>
 <td valign="top">[<a href="#ipi">IPI</a>]</td>
 <td>
-
 List of [Interested Parties Information](https://musicbrainz.org/doc/IPI)
 (IPI) codes for the artist.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>isnis</strong></td>
 <td valign="top">[<a href="#isni">ISNI</a>]</td>
 <td>
-
 List of [International Standard Name Identifier](https://musicbrainz.org/doc/ISNI)
 (ISNI) codes for the artist.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
-
 A list of recordings linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -817,27 +705,21 @@ A list of recordings linked to this entity.
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 A list of releases linked to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">status</td>
 <td valign="top">[<a href="#releasestatus">ReleaseStatus</a>]</td>
 <td>
-
 Filter by one or more release statuses.
-
 </td>
 </tr>
 <tr>
@@ -854,18 +736,14 @@ Filter by one or more release statuses.
 <td colspan="2" valign="top"><strong>releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
-
 A list of release groups linked to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
@@ -882,9 +760,7 @@ Filter by one or more release group types.
 <td colspan="2" valign="top"><strong>works</strong></td>
 <td valign="top"><a href="#workconnection">WorkConnection</a></td>
 <td>
-
 A list of works linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -901,18 +777,14 @@ A list of works linked to this entity.
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -929,18 +801,14 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
-
 The rating users have given to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -974,38 +842,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#artistedge">ArtistEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#artist">Artist</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -1033,30 +893,24 @@ track, etc., and join phrases between them.
 <td colspan="2" valign="top"><strong>artist</strong></td>
 <td valign="top"><a href="#artist">Artist</a></td>
 <td>
-
 The entity representing the artist referenced in the
 credits.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The name of the artist as credited in the specific release,
 track, etc.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>joinPhrase</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Join phrases might include words and/or punctuation to
 separate artist names as they appear on the release, track, etc.
-
 </td>
 </tr>
 </tbody>
@@ -1080,28 +934,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#artist">Artist</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -1126,18 +974,14 @@ entity.
 <td colspan="2" valign="top"><strong>areas</strong></td>
 <td valign="top"><a href="#areaconnection">AreaConnection</a></td>
 <td>
-
 Browse area entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
@@ -1154,63 +998,49 @@ The MBID of a collection in which the entity is found.
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
-
 Browse artist entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">area</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an area to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">recording</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a recording to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">release</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a release to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">releaseGroup</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a release group to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">work</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a work to which the entity is linked.
-
 </td>
 </tr>
 <tr>
@@ -1227,99 +1057,77 @@ The MBID of a work to which the entity is linked.
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 Browse collection entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">area</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an area to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">artist</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an artist to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">editor</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The username of the editor who created the collection.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">event</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an event to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">label</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a label to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">place</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a place to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">recording</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a recording to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">release</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a release to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">releaseGroup</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a release group to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">work</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a work to which the entity is linked.
-
 </td>
 </tr>
 <tr>
@@ -1336,45 +1144,35 @@ The MBID of a work to which the entity is linked.
 <td colspan="2" valign="top"><strong>events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
-
 Browse event entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">area</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an area to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">artist</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an artist to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">place</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a place to which the entity is linked.
-
 </td>
 </tr>
 <tr>
@@ -1391,36 +1189,28 @@ The MBID of a place to which the entity is linked.
 <td colspan="2" valign="top"><strong>labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
-
 Browse label entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">area</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an area to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">release</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a release to which the entity is linked.
-
 </td>
 </tr>
 <tr>
@@ -1437,27 +1227,21 @@ The MBID of a release to which the entity is linked.
 <td colspan="2" valign="top"><strong>places</strong></td>
 <td valign="top"><a href="#placeconnection">PlaceConnection</a></td>
 <td>
-
 Browse place entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">area</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an area to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
@@ -1474,46 +1258,36 @@ The MBID of a collection in which the entity is found.
 <td colspan="2" valign="top"><strong>recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
-
 Browse recording entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">artist</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an artist to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">isrc</td>
 <td valign="top"><a href="#isrc">ISRC</a></td>
 <td>
-
 The [International Standard Recording Code](https://musicbrainz.org/doc/ISRC)
 (ISRC) of the recording.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">release</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a release to which the entity is linked.
-
 </td>
 </tr>
 <tr>
@@ -1530,110 +1304,86 @@ The MBID of a release to which the entity is linked.
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 Browse release entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">area</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an area to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">artist</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an artist to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">discID</td>
 <td valign="top"><a href="#discid">DiscID</a></td>
 <td>
-
 A [disc ID](https://musicbrainz.org/doc/Disc_ID)
 associated with the release.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">label</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a label to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">recording</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a recording to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">releaseGroup</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a release group to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">track</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a track that is included in the release.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">trackArtist</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an artist that appears on a track in the
 release, but is not included in the credits for the release itself.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">status</td>
 <td valign="top">[<a href="#releasestatus">ReleaseStatus</a>]</td>
 <td>
-
 Filter by one or more release statuses.
-
 </td>
 </tr>
 <tr>
@@ -1650,45 +1400,35 @@ Filter by one or more release statuses.
 <td colspan="2" valign="top"><strong>releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
-
 Browse release group entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">artist</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an artist to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">release</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a release to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
@@ -1705,37 +1445,29 @@ Filter by one or more release group types.
 <td colspan="2" valign="top"><strong>works</strong></td>
 <td valign="top"><a href="#workconnection">WorkConnection</a></td>
 <td>
-
 Browse work entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">artist</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an artist to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">iswc</td>
 <td valign="top"><a href="#iswc">ISWC</a></td>
 <td>
-
 The [International Standard Musical Work Code](https://musicbrainz.org/doc/ISWC)
 (ISWC) of the work.
-
 </td>
 </tr>
 <tr>
@@ -1770,73 +1502,57 @@ lists of entities that users can create.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>editor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The username of the editor who created the collection.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>entityType</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The type of entity listed in the collection.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The type of collection.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>areas</strong></td>
 <td valign="top"><a href="#areaconnection">AreaConnection</a></td>
 <td>
-
 The list of areas found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -1853,9 +1569,7 @@ The list of areas found in this collection.
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
-
 The list of artists found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -1872,9 +1586,7 @@ The list of artists found in this collection.
 <td colspan="2" valign="top"><strong>events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
-
 The list of events found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -1891,9 +1603,7 @@ The list of events found in this collection.
 <td colspan="2" valign="top"><strong>instruments</strong></td>
 <td valign="top"><a href="#instrumentconnection">InstrumentConnection</a></td>
 <td>
-
 The list of instruments found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -1910,9 +1620,7 @@ The list of instruments found in this collection.
 <td colspan="2" valign="top"><strong>labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
-
 The list of labels found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -1929,9 +1637,7 @@ The list of labels found in this collection.
 <td colspan="2" valign="top"><strong>places</strong></td>
 <td valign="top"><a href="#placeconnection">PlaceConnection</a></td>
 <td>
-
 The list of places found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -1948,9 +1654,7 @@ The list of places found in this collection.
 <td colspan="2" valign="top"><strong>recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
-
 The list of recordings found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -1967,27 +1671,21 @@ The list of recordings found in this collection.
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 The list of releases found in this collection.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">status</td>
 <td valign="top">[<a href="#releasestatus">ReleaseStatus</a>]</td>
 <td>
-
 Filter by one or more release statuses.
-
 </td>
 </tr>
 <tr>
@@ -2004,18 +1702,14 @@ Filter by one or more release statuses.
 <td colspan="2" valign="top"><strong>releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
-
 The list of release groups found in this collection.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
@@ -2032,9 +1726,7 @@ Filter by one or more release group types.
 <td colspan="2" valign="top"><strong>series</strong></td>
 <td valign="top"><a href="#seriesconnection">SeriesConnection</a></td>
 <td>
-
 The list of series found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -2051,9 +1743,7 @@ The list of series found in this collection.
 <td colspan="2" valign="top"><strong>works</strong></td>
 <td valign="top"><a href="#workconnection">WorkConnection</a></td>
 <td>
-
 The list of works found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -2087,38 +1777,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#collectionedge">CollectionEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#collection">Collection</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -2142,28 +1824,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#collection">Collection</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -2187,18 +1863,14 @@ Geographic coordinates described with latitude and longitude.
 <td colspan="2" valign="top"><strong>latitude</strong></td>
 <td valign="top"><a href="#degrees">Degrees</a></td>
 <td>
-
 The north–south position of a point on the Earth’s surface.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>longitude</strong></td>
 <td valign="top"><a href="#degrees">Degrees</a></td>
 <td>
-
 The east–west position of a point on the Earth’s surface.
-
 </td>
 </tr>
 </tbody>
@@ -2223,54 +1895,42 @@ particular [disc ID](https://musicbrainz.org/doc/Disc_ID).
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>discID</strong></td>
 <td valign="top"><a href="#discid">DiscID</a>!</td>
 <td>
-
 The [disc ID](https://musicbrainz.org/doc/Disc_ID) of this disc.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>offsetCount</strong></td>
 <td valign="top"><a href="#int">Int</a>!</td>
 <td>
-
 The number of offsets (tracks) on the disc.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>offsets</strong></td>
 <td valign="top">[<a href="#int">Int</a>]</td>
 <td>
-
 The sector offset of each track on the disc.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>sectors</strong></td>
 <td valign="top"><a href="#int">Int</a>!</td>
 <td>
-
 The sector offset of the lead-out (the end of the disc).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 The list of releases linked to this disc ID.
-
 </td>
 </tr>
 <tr>
@@ -2306,122 +1966,96 @@ Generally this means live performances, like concerts and festivals.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>lifeSpan</strong></td>
 <td valign="top"><a href="#lifespan">LifeSpan</a></td>
 <td>
-
 The begin and end dates of the entity’s existence. Its exact
 meaning depends on the type of entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>time</strong></td>
 <td valign="top"><a href="#time">Time</a></td>
 <td>
-
 The start time of the event.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cancelled</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
-
 Whether or not the event took place.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>setlist</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A list of songs performed, optionally including links to
 artists and works. See the [setlist documentation](https://musicbrainz.org/doc/Event/Setlist)
 for syntax and examples.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 What kind of event the event is, e.g. concert, festival, etc.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -2438,18 +2072,14 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
-
 The rating users have given to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -2483,38 +2113,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#eventedge">EventEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#event">Event</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -2538,28 +2160,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#event">Event</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -2585,95 +2201,75 @@ used in relationships between two other entities.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>description</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A brief description of the main characteristics of the
 instrument.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The type categorises the instrument by the way the sound is
 created, similar to the [Hornbostel-Sachs](https://en.wikipedia.org/wiki/Hornbostel%E2%80%93Sachs)
 classification.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -2690,9 +2286,7 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -2726,38 +2320,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#instrumentedge">InstrumentEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#instrument">Instrument</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -2781,28 +2367,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#instrument">Instrument</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -2828,152 +2408,120 @@ represent a record company.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>sortName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The string to use for the purpose of ordering by name (for
 example, by moving articles like ‘the’ to the end or a person’s last name to
 the front).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>country</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The country of origin for the label.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
-
 The area in which the label is based.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>lifeSpan</strong></td>
 <td valign="top"><a href="#lifespan">LifeSpan</a></td>
 <td>
-
 The begin and end dates of the entity’s existence. Its exact
 meaning depends on the type of entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>labelCode</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The [“LC” code](https://musicbrainz.org/doc/Label/Label_Code)
 of the label.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>ipis</strong></td>
 <td valign="top">[<a href="#ipi">IPI</a>]</td>
 <td>
-
 List of [Interested Parties Information](https://musicbrainz.org/doc/IPI)
 codes for the label.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A type describing the main activity of the label, e.g.
 imprint, production, distributor, rights society, etc.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 A list of releases linked to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">status</td>
 <td valign="top">[<a href="#releasestatus">ReleaseStatus</a>]</td>
 <td>
-
 Filter by one or more release statuses.
-
 </td>
 </tr>
 <tr>
@@ -2990,18 +2538,14 @@ Filter by one or more release statuses.
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -3018,18 +2562,14 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
-
 The rating users have given to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -3063,38 +2603,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#labeledge">LabelEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#label">Label</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -3118,28 +2650,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#label">Label</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -3164,27 +2690,21 @@ lifetime, including whether it has ended (even if the date is unknown).
 <td colspan="2" valign="top"><strong>begin</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
-
 The start date of the entity’s life span.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>end</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
-
 The end date of the entity’s life span.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>ended</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
-
 Whether or not the entity’s life span has ended.
-
 </td>
 </tr>
 </tbody>
@@ -3208,262 +2728,204 @@ A lookup of an individual MusicBrainz entity by its MBID.
 <td colspan="2" valign="top"><strong>area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
-
 Look up a specific area by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artist</strong></td>
 <td valign="top"><a href="#artist">Artist</a></td>
 <td>
-
 Look up a specific artist by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collection</strong></td>
 <td valign="top"><a href="#collection">Collection</a></td>
 <td>
-
 Look up a specific collection by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disc</strong></td>
 <td valign="top"><a href="#disc">Disc</a></td>
 <td>
-
 Look up a specific physical disc by its disc ID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">discID</td>
 <td valign="top"><a href="#discid">DiscID</a>!</td>
 <td>
-
 The [disc ID](https://musicbrainz.org/doc/Disc_ID)
 of the disc.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>event</strong></td>
 <td valign="top"><a href="#event">Event</a></td>
 <td>
-
 Look up a specific event by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>instrument</strong></td>
 <td valign="top"><a href="#instrument">Instrument</a></td>
 <td>
-
 Look up a specific instrument by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>label</strong></td>
 <td valign="top"><a href="#label">Label</a></td>
 <td>
-
 Look up a specific label by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>place</strong></td>
 <td valign="top"><a href="#place">Place</a></td>
 <td>
-
 Look up a specific place by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>recording</strong></td>
 <td valign="top"><a href="#recording">Recording</a></td>
 <td>
-
 Look up a specific recording by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>release</strong></td>
 <td valign="top"><a href="#release">Release</a></td>
 <td>
-
 Look up a specific release by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>releaseGroup</strong></td>
 <td valign="top"><a href="#releasegroup">ReleaseGroup</a></td>
 <td>
-
 Look up a specific release group by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>series</strong></td>
 <td valign="top"><a href="#series">Series</a></td>
 <td>
-
 Look up a specific series by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>url</strong></td>
 <td valign="top"><a href="#url">URL</a></td>
 <td>
-
 Look up a specific URL by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">resource</td>
 <td valign="top"><a href="#urlstring">URLString</a></td>
 <td>
-
 The web address of the URL entity to look up.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>work</strong></td>
 <td valign="top"><a href="#work">Work</a></td>
 <td>
-
 Look up a specific work by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 </tbody>
@@ -3491,66 +2953,52 @@ cassette) and can optionally also have a title.
 <td colspan="2" valign="top"><strong>title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The title of this particular medium.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>format</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The [format](https://musicbrainz.org/doc/Release/Format) of
 the medium (e.g. CD, DVD, vinyl, cassette).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>formatID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `format`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>position</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The order of this medium in the release (for example, in a
 multi-disc release).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>trackCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The number of audio tracks on this medium.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>discs</strong></td>
 <td valign="top">[<a href="#disc">Disc</a>]</td>
 <td>
-
 A list of physical discs and their disc IDs for this medium.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>tracks</strong></td>
 <td valign="top">[<a href="#track">Track</a>]</td>
 <td>
-
 The list of tracks on the given media.
-
 </td>
 </tr>
 </tbody>
@@ -3574,36 +3022,28 @@ Information about pagination in a connection.
 <td colspan="2" valign="top"><strong>hasNextPage</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a>!</td>
 <td>
-
 When paginating forwards, are there more items?
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>hasPreviousPage</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a>!</td>
 <td>
-
 When paginating backwards, are there more items?
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>startCursor</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 When paginating backwards, the cursor to continue.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>endCursor</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 When paginating forwards, the cursor to continue.
-
 </td>
 </tr>
 </tbody>
@@ -3628,114 +3068,90 @@ or other place where music is performed, recorded, engineered, etc.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>address</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The address describes the location of the place using the
 standard addressing format for the country it is located in.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
-
 The area entity representing the area, such as the city, in
 which the place is located.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>coordinates</strong></td>
 <td valign="top"><a href="#coordinates">Coordinates</a></td>
 <td>
-
 The geographic coordinates of the place.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>lifeSpan</strong></td>
 <td valign="top"><a href="#lifespan">LifeSpan</a></td>
 <td>
-
 The begin and end dates of the entity’s existence. Its exact
 meaning depends on the type of entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The type categorises the place based on its primary
 function.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
-
 A list of events linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -3752,18 +3168,14 @@ A list of events linked to this entity.
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -3780,9 +3192,7 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -3816,38 +3226,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#placeedge">PlaceEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#place">Place</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -3871,28 +3273,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#place">Place</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -3919,18 +3315,14 @@ for the entity.
 <td colspan="2" valign="top"><strong>voteCount</strong></td>
 <td valign="top"><a href="#int">Int</a>!</td>
 <td>
-
 The number of votes that have contributed to the rating.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>value</strong></td>
 <td valign="top"><a href="#float">Float</a></td>
 <td>
-
 The average rating value based on the aggregated votes.
-
 </td>
 </tr>
 </tbody>
@@ -3965,64 +3357,50 @@ or mixing.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official title of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artistCredit</strong> ⚠️</td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
-
 The main credited artist(s).
-
 <p>⚠️ <strong>DEPRECATED</strong></p>
 <blockquote>
-
 The `artistCredit` field has been renamed to
 `artistCredits`, since it is a list of credits and is referred to in the
 plural form throughout the MusicBrainz documentation. This field is deprecated
 and will be removed in a major release in the future. Use the equivalent
 `artistCredits` field.
-
 </blockquote>
 </td>
 </tr>
@@ -4030,47 +3408,37 @@ and will be removed in a major release in the future. Use the equivalent
 <td colspan="2" valign="top"><strong>artistCredits</strong></td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
-
 The main credited artist(s).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>isrcs</strong></td>
 <td valign="top">[<a href="#isrc">ISRC</a>]</td>
 <td>
-
 A list of [International Standard Recording Codes](https://musicbrainz.org/doc/ISRC)
 (ISRCs) for this recording.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>length</strong></td>
 <td valign="top"><a href="#duration">Duration</a></td>
 <td>
-
 An approximation to the length of the recording, calculated
 from the lengths of the tracks using it.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>video</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
-
 Whether this is a video recording.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
-
 A list of artists linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -4087,27 +3455,21 @@ A list of artists linked to this entity.
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 A list of releases linked to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">status</td>
 <td valign="top">[<a href="#releasestatus">ReleaseStatus</a>]</td>
 <td>
-
 Filter by one or more release statuses.
-
 </td>
 </tr>
 <tr>
@@ -4124,18 +3486,14 @@ Filter by one or more release statuses.
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -4152,18 +3510,14 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
-
 The rating users have given to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -4197,38 +3551,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#recordingedge">RecordingEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#recording">Recording</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -4252,28 +3598,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#recording">Recording</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -4299,105 +3639,83 @@ other and to URLs outside MusicBrainz.
 <td colspan="2" valign="top"><strong>target</strong></td>
 <td valign="top"><a href="#entity">Entity</a>!</td>
 <td>
-
 The target entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>direction</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The direction of the relationship.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>targetType</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The type of entity on the receiving end of the relationship.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>sourceCredit</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 How the source entity was actually credited, if different
 from its main (performance) name.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>targetCredit</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 How the target entity was actually credited, if different
 from its main (performance) name.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>begin</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
-
 The date on which the relationship became applicable.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>end</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
-
 The date on which the relationship became no longer applicable.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>ended</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
-
 Whether the relationship still applies.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>attributes</strong></td>
 <td valign="top">[<a href="#string">String</a>]</td>
 <td>
-
 Attributes which modify the relationship. There is a [list
 of all attributes](https://musicbrainz.org/relationship-attributes), but the
 attributes which are available, and how they should be used, depends on the
 relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The type of relationship.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 </tbody>
@@ -4421,38 +3739,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#relationshipedge">RelationshipEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#relationship">Relationship</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -4476,28 +3786,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#relationship">Relationship</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -4521,37 +3825,29 @@ Lists of entity relationships for each entity type.
 <td colspan="2" valign="top"><strong>areas</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -4578,37 +3874,29 @@ field.
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -4635,37 +3923,29 @@ field.
 <td colspan="2" valign="top"><strong>events</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -4692,37 +3972,29 @@ field.
 <td colspan="2" valign="top"><strong>instruments</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -4749,37 +4021,29 @@ field.
 <td colspan="2" valign="top"><strong>labels</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -4806,37 +4070,29 @@ field.
 <td colspan="2" valign="top"><strong>places</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -4863,37 +4119,29 @@ field.
 <td colspan="2" valign="top"><strong>recordings</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -4920,37 +4168,29 @@ field.
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -4977,37 +4217,29 @@ field.
 <td colspan="2" valign="top"><strong>releaseGroups</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -5034,37 +4266,29 @@ field.
 <td colspan="2" valign="top"><strong>series</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -5091,37 +4315,29 @@ field.
 <td colspan="2" valign="top"><strong>urls</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -5148,37 +4364,29 @@ field.
 <td colspan="2" valign="top"><strong>works</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -5226,64 +4434,50 @@ MusicBrainz as one release.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official title of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artistCredit</strong> ⚠️</td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
-
 The main credited artist(s).
-
 <p>⚠️ <strong>DEPRECATED</strong></p>
 <blockquote>
-
 The `artistCredit` field has been renamed to
 `artistCredits`, since it is a list of credits and is referred to in the
 plural form throughout the MusicBrainz documentation. This field is deprecated
 and will be removed in a major release in the future. Use the equivalent
 `artistCredits` field.
-
 </blockquote>
 </td>
 </tr>
@@ -5291,129 +4485,103 @@ and will be removed in a major release in the future. Use the equivalent
 <td colspan="2" valign="top"><strong>artistCredits</strong></td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
-
 The main credited artist(s).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>releaseEvents</strong></td>
 <td valign="top">[<a href="#releaseevent">ReleaseEvent</a>]</td>
 <td>
-
 The release events for this release.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>date</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
-
 The [release date](https://musicbrainz.org/doc/Release/Date)
 is the date in which a release was made available through some sort of
 distribution mechanism.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>country</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The country in which the release was issued.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>asin</strong></td>
 <td valign="top"><a href="#asin">ASIN</a></td>
 <td>
-
 The [Amazon Standard Identification Number](https://musicbrainz.org/doc/ASIN)
 of the release.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>barcode</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The [barcode](https://en.wikipedia.org/wiki/Barcode), if the
 release has one. The most common types found on releases are 12-digit
 [UPCs](https://en.wikipedia.org/wiki/Universal_Product_Code) and 13-digit
 [EANs](https://en.wikipedia.org/wiki/International_Article_Number).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>status</strong></td>
 <td valign="top"><a href="#releasestatus">ReleaseStatus</a></td>
 <td>
-
 The status describes how “official” a release is.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>statusID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `status`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>packaging</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The physical packaging that accompanies the release. See
 the [list of packaging](https://musicbrainz.org/doc/Release/Packaging) for more
 information.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>packagingID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `packaging`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>quality</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Data quality indicates how good the data for a release is.
 It is not a mark of how good or bad the music itself is – for that, use
 [ratings](https://musicbrainz.org/doc/Rating_System).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>media</strong></td>
 <td valign="top">[<a href="#medium">Medium</a>]</td>
 <td>
-
 The media on which the release was distributed.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
-
 A list of artists linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -5430,9 +4598,7 @@ A list of artists linked to this entity.
 <td colspan="2" valign="top"><strong>labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
-
 A list of labels linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -5449,9 +4615,7 @@ A list of labels linked to this entity.
 <td colspan="2" valign="top"><strong>recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
-
 A list of recordings linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -5468,18 +4632,14 @@ A list of recordings linked to this entity.
 <td colspan="2" valign="top"><strong>releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
-
 A list of release groups linked to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
@@ -5496,18 +4656,14 @@ Filter by one or more release group types.
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -5524,9 +4680,7 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -5560,38 +4714,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#releaseedge">ReleaseEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#release">Release</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -5615,28 +4761,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#release">Release</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -5695,64 +4835,50 @@ album – it doesn’t matter how many CDs or editions/versions it had.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official title of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artistCredit</strong> ⚠️</td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
-
 The main credited artist(s).
-
 <p>⚠️ <strong>DEPRECATED</strong></p>
 <blockquote>
-
 The `artistCredit` field has been renamed to
 `artistCredits`, since it is a list of credits and is referred to in the
 plural form throughout the MusicBrainz documentation. This field is deprecated
 and will be removed in a major release in the future. Use the equivalent
 `artistCredits` field.
-
 </blockquote>
 </td>
 </tr>
@@ -5760,69 +4886,55 @@ and will be removed in a major release in the future. Use the equivalent
 <td colspan="2" valign="top"><strong>artistCredits</strong></td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
-
 The main credited artist(s).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>firstReleaseDate</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
-
 The date of the earliest release in the group.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>primaryType</strong></td>
 <td valign="top"><a href="#releasegrouptype">ReleaseGroupType</a></td>
 <td>
-
 The [type](https://musicbrainz.org/doc/Release_Group/Type)
 of a release group describes what kind of releases the release group represents,
 e.g. album, single, soundtrack, compilation, etc. A release group can have a
 “main” type and an unspecified number of additional types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>primaryTypeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `primaryType`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>secondaryTypes</strong></td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Additional [types](https://musicbrainz.org/doc/Release_Group/Type)
 that apply to this release group.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>secondaryTypeIDs</strong></td>
 <td valign="top">[<a href="#mbid">MBID</a>]</td>
 <td>
-
 The MBIDs associated with the values of the `secondaryTypes`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
-
 A list of artists linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -5839,27 +4951,21 @@ A list of artists linked to this entity.
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 A list of releases linked to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">status</td>
 <td valign="top">[<a href="#releasestatus">ReleaseStatus</a>]</td>
 <td>
-
 Filter by one or more release statuses.
-
 </td>
 </tr>
 <tr>
@@ -5876,18 +4982,14 @@ Filter by one or more release statuses.
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -5904,18 +5006,14 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
-
 The rating users have given to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -5949,38 +5047,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#releasegroupedge">ReleaseGroupEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#releasegroup">ReleaseGroup</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -6004,28 +5094,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#releasegroup">ReleaseGroup</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -6049,19 +5133,15 @@ A search for MusicBrainz entities using Lucene query syntax.
 <td colspan="2" valign="top"><strong>areas</strong></td>
 <td valign="top"><a href="#areaconnection">AreaConnection</a></td>
 <td>
-
 Search for area entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6078,19 +5158,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
-
 Search for artist entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6107,19 +5183,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
-
 Search for event entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6136,19 +5208,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>instruments</strong></td>
 <td valign="top"><a href="#instrumentconnection">InstrumentConnection</a></td>
 <td>
-
 Search for instrument entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6165,19 +5233,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
-
 Search for label entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6194,19 +5258,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>places</strong></td>
 <td valign="top"><a href="#placeconnection">PlaceConnection</a></td>
 <td>
-
 Search for place entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6223,19 +5283,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
-
 Search for recording entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6252,19 +5308,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 Search for release entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6281,19 +5333,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
-
 Search for release group entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6310,19 +5358,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>series</strong></td>
 <td valign="top"><a href="#seriesconnection">SeriesConnection</a></td>
 <td>
-
 Search for series entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6339,19 +5383,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>works</strong></td>
 <td valign="top"><a href="#workconnection">WorkConnection</a></td>
 <td>
-
 Search for work entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6387,74 +5427,58 @@ theme.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The type primarily describes what type of entity the series
 contains.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -6471,9 +5495,7 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -6507,38 +5529,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#seriesedge">SeriesEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#series">Series</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -6562,28 +5576,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#series">Series</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -6609,18 +5617,14 @@ release, or recording.
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The tag label.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>count</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 How many times this tag has been applied to the entity.
-
 </td>
 </tr>
 </tbody>
@@ -6644,38 +5648,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#tagedge">TagEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#tag">Tag</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -6699,28 +5695,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#tag">Tag</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -6746,56 +5736,44 @@ A track is the way a recording is represented on a particular
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official title of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>position</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The track’s position on the overall release (including all
 tracks from all discs).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>number</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The track number, which may include information about the
 disc or side it appears on, e.g. “A1” or “B3”.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>length</strong></td>
 <td valign="top"><a href="#duration">Duration</a></td>
 <td>
-
 The length of the track.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>recording</strong></td>
 <td valign="top"><a href="#recording">Recording</a></td>
 <td>
-
 The recording that appears on the track.
-
 </td>
 </tr>
 </tbody>
@@ -6821,36 +5799,28 @@ acquired, an entry in another database, etc.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>resource</strong></td>
 <td valign="top"><a href="#urlstring">URLString</a>!</td>
 <td>
-
 The actual URL string.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 </tbody>
@@ -6876,93 +5846,73 @@ more audio recordings.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official title of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>iswcs</strong></td>
 <td valign="top">[<a href="#string">String</a>]</td>
 <td>
-
 A list of [ISWCs](https://musicbrainz.org/doc/ISWC) assigned
 to the work by copyright collecting agencies.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>language</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The language in which the work was originally written.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The type of work.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
-
 A list of artists linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -6979,18 +5929,14 @@ A list of artists linked to this entity.
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -7007,18 +5953,14 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
-
 The rating users have given to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -7052,38 +5994,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#workedge">WorkEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#work">Work</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -7107,28 +6041,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#work">Work</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -7150,130 +6078,103 @@ etc.
 <tr>
 <td valign="top"><strong>ALBUM</strong></td>
 <td>
-
 An album, perhaps better defined as a “Long Play” (LP)
 release, generally consists of previously unreleased material (unless this type
 is combined with secondary types which change that, such as “Compilation”). This
 includes album re-issues, with or without bonus tracks.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>SINGLE</strong></td>
 <td>
-
 A single typically has one main song and possibly a handful
 of additional tracks or remixes of the main track. A single is usually named
 after its main song.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>EP</strong></td>
 <td>
-
 An EP is a so-called “Extended Play” release and often
 contains the letters EP in the title. Generally an EP will be shorter than a
 full length release (an LP or “Long Play”) and the tracks are usually exclusive
 to the EP, in other words the tracks don’t come from a previously issued
 release. EP is fairly difficult to define; usually it should only be assumed
 that a release is an EP if the artist defines it as such.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>OTHER</strong></td>
 <td>
-
 Any release that does not fit any of the other categories.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>BROADCAST</strong></td>
 <td>
-
 An episodic release that was originally broadcast via radio,
 television, or the Internet, including podcasts.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>COMPILATION</strong></td>
 <td>
-
 A compilation is a collection of previously released tracks
 by one or more artists.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>SOUNDTRACK</strong></td>
 <td>
-
 A soundtrack is the musical score to a movie, TV series,
 stage show, computer game, etc.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>SPOKENWORD</strong></td>
 <td>
-
 A non-music spoken word release.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>INTERVIEW</strong></td>
 <td>
-
 An interview release contains an interview, generally with
 an artist.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>AUDIOBOOK</strong></td>
 <td>
-
 An audiobook is a book read by a narrator without music.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>LIVE</strong></td>
 <td>
-
 A release that was recorded live.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>REMIX</strong></td>
 <td>
-
 A release that was (re)mixed from previously released
 material.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>DJMIX</strong></td>
 <td>
-
 A DJ-mix is a sequence of several recordings played one
 after the other, each one modified so that they blend together into a continuous
 flow of music. A DJ mix release requires that the recordings be modified in some
 manner, and the DJ who does this modification is usually (although not always)
 credited in a fairly prominent way.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>MIXTAPE</strong></td>
 <td>
-
 Promotional in nature (but not necessarily free), mixtapes
 and street albums are often released by artists to promote new artists, or
 upcoming studio albums by prominent artists. They are also sometimes used to
@@ -7286,24 +6187,19 @@ significant proportion of new material, including original production or
 original vocals over top of other artists’ instrumentals. They are distinct from
 demos in that they are designed for release directly to the public and fans, not
 to labels.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>DEMO</strong></td>
 <td>
-
 A release that was recorded for limited circulation or
 reference use rather than for general public release.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>NAT</strong></td>
 <td>
-
 A non-album track (special case).
-
 </td>
 </tr>
 </tbody>
@@ -7323,38 +6219,30 @@ bootleg, etc.
 <tr>
 <td valign="top"><strong>OFFICIAL</strong></td>
 <td>
-
 Any release officially sanctioned by the artist and/or their
 record company. (Most releases will fit into this category.)
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>PROMOTION</strong></td>
 <td>
-
 A giveaway release or a release intended to promote an
 upcoming official release, e.g. prerelease albums or releases included with a
 magazine.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>BOOTLEG</strong></td>
 <td>
-
 An unofficial/underground release that was not sanctioned by
 the artist and/or the record company.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>PSEUDORELEASE</strong></td>
 <td>
-
 A pseudo-release is a duplicate release for
 translation/transliteration purposes.
-
 </td>
 </tr>
 </tbody>
@@ -7486,9 +6374,7 @@ An entity in the MusicBrainz schema.
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 </tbody>
@@ -7512,9 +6398,7 @@ An object with an ID
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The id of the object.
-
 </td>
 </tr>
 </tbody>

--- a/test/fixtures/graphbrainz-updateSchema-updated.md
+++ b/test/fixtures/graphbrainz-updateSchema-updated.md
@@ -114,45 +114,35 @@ requests can be made.
 <td colspan="2" valign="top"><strong>lookup</strong></td>
 <td valign="top"><a href="#lookupquery">LookupQuery</a></td>
 <td>
-
 Perform a lookup of a MusicBrainz entity by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>browse</strong></td>
 <td valign="top"><a href="#browsequery">BrowseQuery</a></td>
 <td>
-
 Browse all MusicBrainz entities directly linked to another entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>search</strong></td>
 <td valign="top"><a href="#searchquery">SearchQuery</a></td>
 <td>
-
 Search for MusicBrainz entities using Lucene query syntax.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#node">Node</a></td>
 <td>
-
 Fetches an object given its ID
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">id</td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 </tbody>
@@ -180,60 +170,48 @@ entity will be given as a result – even if the actual name wouldn’t be.
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The aliased name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>sortName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The string to use for the purpose of ordering by name (for
 example, by moving articles like ‘the’ to the end or a person’s last name to
 the front).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>locale</strong></td>
 <td valign="top"><a href="#locale">Locale</a></td>
 <td>
-
 The locale (language and/or country) in which the alias is
 used.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>primary</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
-
 Whether this is the main alias for the entity in the
 specified locale (this could mean the most recent or the most common).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The type or purpose of the alias – whether it is a variant,
 search hint, etc.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 </tbody>
@@ -258,106 +236,84 @@ or settlements (countries, cities, or the like).
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>sortName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The string to use for the purpose of ordering by name (for
 example, by moving articles like ‘the’ to the end or a person’s last name to
 the front).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>isoCodes</strong></td>
 <td valign="top">[<a href="#string">String</a>]</td>
 <td>
-
 [ISO 3166 codes](https://en.wikipedia.org/wiki/ISO_3166) are
 the codes assigned by ISO to countries and subdivisions.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">standard</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Specify the particular ISO standard codes to retrieve.
 Available ISO standards are 3166-1, 3166-2, and 3166-3.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The type of area (country, city, etc. – see the [possible
 values](https://musicbrainz.org/doc/Area)).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
-
 A list of artists linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -374,9 +330,7 @@ A list of artists linked to this entity.
 <td colspan="2" valign="top"><strong>events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
-
 A list of events linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -393,9 +347,7 @@ A list of events linked to this entity.
 <td colspan="2" valign="top"><strong>labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
-
 A list of labels linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -412,9 +364,7 @@ A list of labels linked to this entity.
 <td colspan="2" valign="top"><strong>places</strong></td>
 <td valign="top"><a href="#placeconnection">PlaceConnection</a></td>
 <td>
-
 A list of places linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -431,27 +381,21 @@ A list of places linked to this entity.
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 A list of releases linked to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">status</td>
 <td valign="top">[<a href="#releasestatus">ReleaseStatus</a>]</td>
 <td>
-
 Filter by one or more release statuses.
-
 </td>
 </tr>
 <tr>
@@ -468,18 +412,14 @@ Filter by one or more release statuses.
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -496,9 +436,7 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -532,38 +470,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#areaedge">AreaEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#area">Area</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -587,28 +517,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -636,175 +560,139 @@ even a fictional character.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>sortName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The string to use for the purpose of ordering by name (for
 example, by moving articles like ‘the’ to the end or a person’s last name to
 the front).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>country</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The country with which an artist is primarily identified. It
 is often, but not always, its birth/formation country.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
-
 The area with which an artist is primarily identified. It
 is often, but not always, its birth/formation country.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>beginArea</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
-
 The area in which an artist began their career (or where
 they were born, if the artist is a person).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>endArea</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
-
 The area in which an artist ended their career (or where
 they died, if the artist is a person).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>lifeSpan</strong></td>
 <td valign="top"><a href="#lifespan">LifeSpan</a></td>
 <td>
-
 The begin and end dates of the entity’s existence. Its exact
 meaning depends on the type of entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>gender</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Whether a person or character identifies as male, female, or
 neither. Groups do not have genders.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>genderID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `gender`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Whether an artist is a person, a group, or something else.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>ipis</strong></td>
 <td valign="top">[<a href="#ipi">IPI</a>]</td>
 <td>
-
 List of [Interested Parties Information](https://musicbrainz.org/doc/IPI)
 (IPI) codes for the artist.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>isnis</strong></td>
 <td valign="top">[<a href="#isni">ISNI</a>]</td>
 <td>
-
 List of [International Standard Name Identifier](https://musicbrainz.org/doc/ISNI)
 (ISNI) codes for the artist.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
-
 A list of recordings linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -821,27 +709,21 @@ A list of recordings linked to this entity.
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 A list of releases linked to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">status</td>
 <td valign="top">[<a href="#releasestatus">ReleaseStatus</a>]</td>
 <td>
-
 Filter by one or more release statuses.
-
 </td>
 </tr>
 <tr>
@@ -858,18 +740,14 @@ Filter by one or more release statuses.
 <td colspan="2" valign="top"><strong>releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
-
 A list of release groups linked to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
@@ -886,9 +764,7 @@ Filter by one or more release group types.
 <td colspan="2" valign="top"><strong>works</strong></td>
 <td valign="top"><a href="#workconnection">WorkConnection</a></td>
 <td>
-
 A list of works linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -905,18 +781,14 @@ A list of works linked to this entity.
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -933,18 +805,14 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
-
 The rating users have given to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -978,38 +846,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#artistedge">ArtistEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#artist">Artist</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -1037,30 +897,24 @@ track, etc., and join phrases between them.
 <td colspan="2" valign="top"><strong>artist</strong></td>
 <td valign="top"><a href="#artist">Artist</a></td>
 <td>
-
 The entity representing the artist referenced in the
 credits.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The name of the artist as credited in the specific release,
 track, etc.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>joinPhrase</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Join phrases might include words and/or punctuation to
 separate artist names as they appear on the release, track, etc.
-
 </td>
 </tr>
 </tbody>
@@ -1084,28 +938,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#artist">Artist</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -1130,18 +978,14 @@ entity.
 <td colspan="2" valign="top"><strong>areas</strong></td>
 <td valign="top"><a href="#areaconnection">AreaConnection</a></td>
 <td>
-
 Browse area entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
@@ -1158,63 +1002,49 @@ The MBID of a collection in which the entity is found.
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
-
 Browse artist entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">area</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an area to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">recording</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a recording to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">release</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a release to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">releaseGroup</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a release group to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">work</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a work to which the entity is linked.
-
 </td>
 </tr>
 <tr>
@@ -1231,99 +1061,77 @@ The MBID of a work to which the entity is linked.
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 Browse collection entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">area</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an area to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">artist</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an artist to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">editor</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The username of the editor who created the collection.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">event</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an event to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">label</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a label to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">place</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a place to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">recording</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a recording to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">release</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a release to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">releaseGroup</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a release group to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">work</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a work to which the entity is linked.
-
 </td>
 </tr>
 <tr>
@@ -1340,45 +1148,35 @@ The MBID of a work to which the entity is linked.
 <td colspan="2" valign="top"><strong>events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
-
 Browse event entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">area</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an area to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">artist</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an artist to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">place</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a place to which the entity is linked.
-
 </td>
 </tr>
 <tr>
@@ -1395,36 +1193,28 @@ The MBID of a place to which the entity is linked.
 <td colspan="2" valign="top"><strong>labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
-
 Browse label entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">area</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an area to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">release</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a release to which the entity is linked.
-
 </td>
 </tr>
 <tr>
@@ -1441,27 +1231,21 @@ The MBID of a release to which the entity is linked.
 <td colspan="2" valign="top"><strong>places</strong></td>
 <td valign="top"><a href="#placeconnection">PlaceConnection</a></td>
 <td>
-
 Browse place entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">area</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an area to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
@@ -1478,46 +1262,36 @@ The MBID of a collection in which the entity is found.
 <td colspan="2" valign="top"><strong>recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
-
 Browse recording entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">artist</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an artist to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">isrc</td>
 <td valign="top"><a href="#isrc">ISRC</a></td>
 <td>
-
 The [International Standard Recording Code](https://musicbrainz.org/doc/ISRC)
 (ISRC) of the recording.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">release</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a release to which the entity is linked.
-
 </td>
 </tr>
 <tr>
@@ -1534,110 +1308,86 @@ The MBID of a release to which the entity is linked.
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 Browse release entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">area</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an area to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">artist</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an artist to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">discID</td>
 <td valign="top"><a href="#discid">DiscID</a></td>
 <td>
-
 A [disc ID](https://musicbrainz.org/doc/Disc_ID)
 associated with the release.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">label</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a label to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">recording</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a recording to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">releaseGroup</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a release group to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">track</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a track that is included in the release.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">trackArtist</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an artist that appears on a track in the
 release, but is not included in the credits for the release itself.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">status</td>
 <td valign="top">[<a href="#releasestatus">ReleaseStatus</a>]</td>
 <td>
-
 Filter by one or more release statuses.
-
 </td>
 </tr>
 <tr>
@@ -1654,45 +1404,35 @@ Filter by one or more release statuses.
 <td colspan="2" valign="top"><strong>releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
-
 Browse release group entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">artist</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an artist to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">release</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a release to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
@@ -1709,37 +1449,29 @@ Filter by one or more release group types.
 <td colspan="2" valign="top"><strong>works</strong></td>
 <td valign="top"><a href="#workconnection">WorkConnection</a></td>
 <td>
-
 Browse work entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">artist</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an artist to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">iswc</td>
 <td valign="top"><a href="#iswc">ISWC</a></td>
 <td>
-
 The [International Standard Musical Work Code](https://musicbrainz.org/doc/ISWC)
 (ISWC) of the work.
-
 </td>
 </tr>
 <tr>
@@ -1774,73 +1506,57 @@ lists of entities that users can create.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>editor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The username of the editor who created the collection.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>entityType</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The type of entity listed in the collection.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The type of collection.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>areas</strong></td>
 <td valign="top"><a href="#areaconnection">AreaConnection</a></td>
 <td>
-
 The list of areas found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -1857,9 +1573,7 @@ The list of areas found in this collection.
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
-
 The list of artists found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -1876,9 +1590,7 @@ The list of artists found in this collection.
 <td colspan="2" valign="top"><strong>events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
-
 The list of events found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -1895,9 +1607,7 @@ The list of events found in this collection.
 <td colspan="2" valign="top"><strong>instruments</strong></td>
 <td valign="top"><a href="#instrumentconnection">InstrumentConnection</a></td>
 <td>
-
 The list of instruments found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -1914,9 +1624,7 @@ The list of instruments found in this collection.
 <td colspan="2" valign="top"><strong>labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
-
 The list of labels found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -1933,9 +1641,7 @@ The list of labels found in this collection.
 <td colspan="2" valign="top"><strong>places</strong></td>
 <td valign="top"><a href="#placeconnection">PlaceConnection</a></td>
 <td>
-
 The list of places found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -1952,9 +1658,7 @@ The list of places found in this collection.
 <td colspan="2" valign="top"><strong>recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
-
 The list of recordings found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -1971,27 +1675,21 @@ The list of recordings found in this collection.
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 The list of releases found in this collection.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">status</td>
 <td valign="top">[<a href="#releasestatus">ReleaseStatus</a>]</td>
 <td>
-
 Filter by one or more release statuses.
-
 </td>
 </tr>
 <tr>
@@ -2008,18 +1706,14 @@ Filter by one or more release statuses.
 <td colspan="2" valign="top"><strong>releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
-
 The list of release groups found in this collection.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
@@ -2036,9 +1730,7 @@ Filter by one or more release group types.
 <td colspan="2" valign="top"><strong>series</strong></td>
 <td valign="top"><a href="#seriesconnection">SeriesConnection</a></td>
 <td>
-
 The list of series found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -2055,9 +1747,7 @@ The list of series found in this collection.
 <td colspan="2" valign="top"><strong>works</strong></td>
 <td valign="top"><a href="#workconnection">WorkConnection</a></td>
 <td>
-
 The list of works found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -2091,38 +1781,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#collectionedge">CollectionEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#collection">Collection</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -2146,28 +1828,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#collection">Collection</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -2191,18 +1867,14 @@ Geographic coordinates described with latitude and longitude.
 <td colspan="2" valign="top"><strong>latitude</strong></td>
 <td valign="top"><a href="#degrees">Degrees</a></td>
 <td>
-
 The north–south position of a point on the Earth’s surface.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>longitude</strong></td>
 <td valign="top"><a href="#degrees">Degrees</a></td>
 <td>
-
 The east–west position of a point on the Earth’s surface.
-
 </td>
 </tr>
 </tbody>
@@ -2226,82 +1898,64 @@ An individual piece of album artwork from the [Cover Art Archive](https://musicb
 <td colspan="2" valign="top"><strong>fileID</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The Internet Archive’s internal file ID for the image.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>image</strong></td>
 <td valign="top"><a href="#urlstring">URLString</a>!</td>
 <td>
-
 The URL at which the image can be found.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>thumbnails</strong></td>
 <td valign="top"><a href="#coverartarchiveimagethumbnails">CoverArtArchiveImageThumbnails</a>!</td>
 <td>
-
 A set of thumbnails for the image.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>front</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a>!</td>
 <td>
-
 Whether this image depicts the “main front” of the release.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>back</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a>!</td>
 <td>
-
 Whether this image depicts the “main back” of the release.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>types</strong></td>
 <td valign="top">[<a href="#string">String</a>]!</td>
 <td>
-
 A list of [image types](https://musicbrainz.org/doc/Cover_Art/Types)
 describing what part(s) of the release the image includes.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edit</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The MusicBrainz edit ID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>approved</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
-
 Whether the image was approved by the MusicBrainz edit system.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>comment</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A free-text comment left for the image.
-
 </td>
 </tr>
 </tbody>
@@ -2325,20 +1979,16 @@ URLs for thumbnails of different sizes for a particular piece of cover art.
 <td colspan="2" valign="top"><strong>small</strong></td>
 <td valign="top"><a href="#urlstring">URLString</a></td>
 <td>
-
 The URL of a small version of the cover art, where the maximum dimension is
 250px.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>large</strong></td>
 <td valign="top"><a href="#urlstring">URLString</a></td>
 <td>
-
 The URL of a large version of the cover art, where the maximum dimension is
 500px.
-
 </td>
 </tr>
 </tbody>
@@ -2364,7 +2014,6 @@ as well as a summary of what artwork is available.
 <td colspan="2" valign="top"><strong>front</strong></td>
 <td valign="top"><a href="#urlstring">URLString</a></td>
 <td>
-
 The URL of an image depicting the album cover or “main front” of the release,
 i.e. the front of the packaging of the audio recording (or in the case of a
 digital release, the image associated with it in a digital media store).
@@ -2373,25 +2022,21 @@ In the MusicBrainz schema, this field is a Boolean value indicating the
 presence of a front image, whereas here the value is the URL for the image
 itself if one exists. You can check for null if you just want to determine
 the presence of an image.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">size</td>
 <td valign="top"><a href="#coverartarchiveimagesize">CoverArtArchiveImageSize</a></td>
 <td>
-
 The size of the image to retrieve. By default, the returned image will
 have its full original dimensions, but certain thumbnail sizes may be
 retrieved as well.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>back</strong></td>
 <td valign="top"><a href="#urlstring">URLString</a></td>
 <td>
-
 The URL of an image depicting the “main back” of the release, i.e. the back
 of the packaging of the audio recording.
 
@@ -2399,55 +2044,44 @@ In the MusicBrainz schema, this field is a Boolean value indicating the
 presence of a back image, whereas here the value is the URL for the image
 itself. You can check for null if you just want to determine the presence of
 an image.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">size</td>
 <td valign="top"><a href="#coverartarchiveimagesize">CoverArtArchiveImageSize</a></td>
 <td>
-
 The size of the image to retrieve. By default, the returned image will
 have its full original dimensions, but certain thumbnail sizes may be
 retrieved as well.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>images</strong></td>
 <td valign="top">[<a href="#coverartarchiveimage">CoverArtArchiveImage</a>]!</td>
 <td>
-
 A list of images depicting the different sides and surfaces of a release’s
 media and packaging.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artwork</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a>!</td>
 <td>
-
 Whether there is artwork present for this release.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>count</strong></td>
 <td valign="top"><a href="#int">Int</a>!</td>
 <td>
-
 The number of artwork images present for this release.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>release</strong></td>
 <td valign="top"><a href="#release">Release</a></td>
 <td>
-
 The particular release shown in the returned cover art.
-
 </td>
 </tr>
 </tbody>
@@ -2472,54 +2106,42 @@ particular [disc ID](https://musicbrainz.org/doc/Disc_ID).
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>discID</strong></td>
 <td valign="top"><a href="#discid">DiscID</a>!</td>
 <td>
-
 The [disc ID](https://musicbrainz.org/doc/Disc_ID) of this disc.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>offsetCount</strong></td>
 <td valign="top"><a href="#int">Int</a>!</td>
 <td>
-
 The number of offsets (tracks) on the disc.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>offsets</strong></td>
 <td valign="top">[<a href="#int">Int</a>]</td>
 <td>
-
 The sector offset of each track on the disc.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>sectors</strong></td>
 <td valign="top"><a href="#int">Int</a>!</td>
 <td>
-
 The sector offset of the lead-out (the end of the disc).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 The list of releases linked to this disc ID.
-
 </td>
 </tr>
 <tr>
@@ -2555,122 +2177,96 @@ Generally this means live performances, like concerts and festivals.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>lifeSpan</strong></td>
 <td valign="top"><a href="#lifespan">LifeSpan</a></td>
 <td>
-
 The begin and end dates of the entity’s existence. Its exact
 meaning depends on the type of entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>time</strong></td>
 <td valign="top"><a href="#time">Time</a></td>
 <td>
-
 The start time of the event.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cancelled</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
-
 Whether or not the event took place.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>setlist</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A list of songs performed, optionally including links to
 artists and works. See the [setlist documentation](https://musicbrainz.org/doc/Event/Setlist)
 for syntax and examples.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 What kind of event the event is, e.g. concert, festival, etc.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -2687,18 +2283,14 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
-
 The rating users have given to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -2732,38 +2324,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#eventedge">EventEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#event">Event</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -2787,28 +2371,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#event">Event</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -2834,95 +2412,75 @@ used in relationships between two other entities.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>description</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A brief description of the main characteristics of the
 instrument.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The type categorises the instrument by the way the sound is
 created, similar to the [Hornbostel-Sachs](https://en.wikipedia.org/wiki/Hornbostel%E2%80%93Sachs)
 classification.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -2939,9 +2497,7 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -2975,38 +2531,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#instrumentedge">InstrumentEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#instrument">Instrument</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -3030,28 +2578,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#instrument">Instrument</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -3077,152 +2619,120 @@ represent a record company.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>sortName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The string to use for the purpose of ordering by name (for
 example, by moving articles like ‘the’ to the end or a person’s last name to
 the front).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>country</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The country of origin for the label.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
-
 The area in which the label is based.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>lifeSpan</strong></td>
 <td valign="top"><a href="#lifespan">LifeSpan</a></td>
 <td>
-
 The begin and end dates of the entity’s existence. Its exact
 meaning depends on the type of entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>labelCode</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The [“LC” code](https://musicbrainz.org/doc/Label/Label_Code)
 of the label.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>ipis</strong></td>
 <td valign="top">[<a href="#ipi">IPI</a>]</td>
 <td>
-
 List of [Interested Parties Information](https://musicbrainz.org/doc/IPI)
 codes for the label.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A type describing the main activity of the label, e.g.
 imprint, production, distributor, rights society, etc.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 A list of releases linked to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">status</td>
 <td valign="top">[<a href="#releasestatus">ReleaseStatus</a>]</td>
 <td>
-
 Filter by one or more release statuses.
-
 </td>
 </tr>
 <tr>
@@ -3239,18 +2749,14 @@ Filter by one or more release statuses.
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -3267,18 +2773,14 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
-
 The rating users have given to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -3312,38 +2814,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#labeledge">LabelEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#label">Label</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -3367,28 +2861,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#label">Label</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -3413,27 +2901,21 @@ lifetime, including whether it has ended (even if the date is unknown).
 <td colspan="2" valign="top"><strong>begin</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
-
 The start date of the entity’s life span.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>end</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
-
 The end date of the entity’s life span.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>ended</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
-
 Whether or not the entity’s life span has ended.
-
 </td>
 </tr>
 </tbody>
@@ -3457,262 +2939,204 @@ A lookup of an individual MusicBrainz entity by its MBID.
 <td colspan="2" valign="top"><strong>area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
-
 Look up a specific area by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artist</strong></td>
 <td valign="top"><a href="#artist">Artist</a></td>
 <td>
-
 Look up a specific artist by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collection</strong></td>
 <td valign="top"><a href="#collection">Collection</a></td>
 <td>
-
 Look up a specific collection by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disc</strong></td>
 <td valign="top"><a href="#disc">Disc</a></td>
 <td>
-
 Look up a specific physical disc by its disc ID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">discID</td>
 <td valign="top"><a href="#discid">DiscID</a>!</td>
 <td>
-
 The [disc ID](https://musicbrainz.org/doc/Disc_ID)
 of the disc.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>event</strong></td>
 <td valign="top"><a href="#event">Event</a></td>
 <td>
-
 Look up a specific event by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>instrument</strong></td>
 <td valign="top"><a href="#instrument">Instrument</a></td>
 <td>
-
 Look up a specific instrument by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>label</strong></td>
 <td valign="top"><a href="#label">Label</a></td>
 <td>
-
 Look up a specific label by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>place</strong></td>
 <td valign="top"><a href="#place">Place</a></td>
 <td>
-
 Look up a specific place by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>recording</strong></td>
 <td valign="top"><a href="#recording">Recording</a></td>
 <td>
-
 Look up a specific recording by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>release</strong></td>
 <td valign="top"><a href="#release">Release</a></td>
 <td>
-
 Look up a specific release by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>releaseGroup</strong></td>
 <td valign="top"><a href="#releasegroup">ReleaseGroup</a></td>
 <td>
-
 Look up a specific release group by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>series</strong></td>
 <td valign="top"><a href="#series">Series</a></td>
 <td>
-
 Look up a specific series by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>url</strong></td>
 <td valign="top"><a href="#url">URL</a></td>
 <td>
-
 Look up a specific URL by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">resource</td>
 <td valign="top"><a href="#urlstring">URLString</a></td>
 <td>
-
 The web address of the URL entity to look up.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>work</strong></td>
 <td valign="top"><a href="#work">Work</a></td>
 <td>
-
 Look up a specific work by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 </tbody>
@@ -3740,66 +3164,52 @@ cassette) and can optionally also have a title.
 <td colspan="2" valign="top"><strong>title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The title of this particular medium.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>format</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The [format](https://musicbrainz.org/doc/Release/Format) of
 the medium (e.g. CD, DVD, vinyl, cassette).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>formatID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `format`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>position</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The order of this medium in the release (for example, in a
 multi-disc release).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>trackCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The number of audio tracks on this medium.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>discs</strong></td>
 <td valign="top">[<a href="#disc">Disc</a>]</td>
 <td>
-
 A list of physical discs and their disc IDs for this medium.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>tracks</strong></td>
 <td valign="top">[<a href="#track">Track</a>]</td>
 <td>
-
 The list of tracks on the given media.
-
 </td>
 </tr>
 </tbody>
@@ -3823,36 +3233,28 @@ Information about pagination in a connection.
 <td colspan="2" valign="top"><strong>hasNextPage</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a>!</td>
 <td>
-
 When paginating forwards, are there more items?
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>hasPreviousPage</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a>!</td>
 <td>
-
 When paginating backwards, are there more items?
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>startCursor</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 When paginating backwards, the cursor to continue.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>endCursor</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 When paginating forwards, the cursor to continue.
-
 </td>
 </tr>
 </tbody>
@@ -3877,114 +3279,90 @@ or other place where music is performed, recorded, engineered, etc.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>address</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The address describes the location of the place using the
 standard addressing format for the country it is located in.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
-
 The area entity representing the area, such as the city, in
 which the place is located.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>coordinates</strong></td>
 <td valign="top"><a href="#coordinates">Coordinates</a></td>
 <td>
-
 The geographic coordinates of the place.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>lifeSpan</strong></td>
 <td valign="top"><a href="#lifespan">LifeSpan</a></td>
 <td>
-
 The begin and end dates of the entity’s existence. Its exact
 meaning depends on the type of entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The type categorises the place based on its primary
 function.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
-
 A list of events linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -4001,18 +3379,14 @@ A list of events linked to this entity.
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -4029,9 +3403,7 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -4065,38 +3437,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#placeedge">PlaceEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#place">Place</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -4120,28 +3484,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#place">Place</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -4168,18 +3526,14 @@ for the entity.
 <td colspan="2" valign="top"><strong>voteCount</strong></td>
 <td valign="top"><a href="#int">Int</a>!</td>
 <td>
-
 The number of votes that have contributed to the rating.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>value</strong></td>
 <td valign="top"><a href="#float">Float</a></td>
 <td>
-
 The average rating value based on the aggregated votes.
-
 </td>
 </tr>
 </tbody>
@@ -4214,64 +3568,50 @@ or mixing.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official title of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artistCredit</strong> ⚠️</td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
-
 The main credited artist(s).
-
 <p>⚠️ <strong>DEPRECATED</strong></p>
 <blockquote>
-
 The `artistCredit` field has been renamed to
 `artistCredits`, since it is a list of credits and is referred to in the
 plural form throughout the MusicBrainz documentation. This field is deprecated
 and will be removed in a major release in the future. Use the equivalent
 `artistCredits` field.
-
 </blockquote>
 </td>
 </tr>
@@ -4279,47 +3619,37 @@ and will be removed in a major release in the future. Use the equivalent
 <td colspan="2" valign="top"><strong>artistCredits</strong></td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
-
 The main credited artist(s).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>isrcs</strong></td>
 <td valign="top">[<a href="#isrc">ISRC</a>]</td>
 <td>
-
 A list of [International Standard Recording Codes](https://musicbrainz.org/doc/ISRC)
 (ISRCs) for this recording.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>length</strong></td>
 <td valign="top"><a href="#duration">Duration</a></td>
 <td>
-
 An approximation to the length of the recording, calculated
 from the lengths of the tracks using it.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>video</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
-
 Whether this is a video recording.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
-
 A list of artists linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -4336,27 +3666,21 @@ A list of artists linked to this entity.
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 A list of releases linked to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">status</td>
 <td valign="top">[<a href="#releasestatus">ReleaseStatus</a>]</td>
 <td>
-
 Filter by one or more release statuses.
-
 </td>
 </tr>
 <tr>
@@ -4373,18 +3697,14 @@ Filter by one or more release statuses.
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -4401,18 +3721,14 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
-
 The rating users have given to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -4446,38 +3762,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#recordingedge">RecordingEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#recording">Recording</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -4501,28 +3809,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#recording">Recording</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -4548,105 +3850,83 @@ other and to URLs outside MusicBrainz.
 <td colspan="2" valign="top"><strong>target</strong></td>
 <td valign="top"><a href="#entity">Entity</a>!</td>
 <td>
-
 The target entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>direction</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The direction of the relationship.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>targetType</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The type of entity on the receiving end of the relationship.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>sourceCredit</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 How the source entity was actually credited, if different
 from its main (performance) name.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>targetCredit</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 How the target entity was actually credited, if different
 from its main (performance) name.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>begin</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
-
 The date on which the relationship became applicable.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>end</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
-
 The date on which the relationship became no longer applicable.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>ended</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
-
 Whether the relationship still applies.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>attributes</strong></td>
 <td valign="top">[<a href="#string">String</a>]</td>
 <td>
-
 Attributes which modify the relationship. There is a [list
 of all attributes](https://musicbrainz.org/relationship-attributes), but the
 attributes which are available, and how they should be used, depends on the
 relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The type of relationship.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 </tbody>
@@ -4670,38 +3950,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#relationshipedge">RelationshipEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#relationship">Relationship</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -4725,28 +3997,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#relationship">Relationship</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -4770,37 +4036,29 @@ Lists of entity relationships for each entity type.
 <td colspan="2" valign="top"><strong>areas</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -4827,37 +4085,29 @@ field.
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -4884,37 +4134,29 @@ field.
 <td colspan="2" valign="top"><strong>events</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -4941,37 +4183,29 @@ field.
 <td colspan="2" valign="top"><strong>instruments</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -4998,37 +4232,29 @@ field.
 <td colspan="2" valign="top"><strong>labels</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -5055,37 +4281,29 @@ field.
 <td colspan="2" valign="top"><strong>places</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -5112,37 +4330,29 @@ field.
 <td colspan="2" valign="top"><strong>recordings</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -5169,37 +4379,29 @@ field.
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -5226,37 +4428,29 @@ field.
 <td colspan="2" valign="top"><strong>releaseGroups</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -5283,37 +4477,29 @@ field.
 <td colspan="2" valign="top"><strong>series</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -5340,37 +4526,29 @@ field.
 <td colspan="2" valign="top"><strong>urls</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -5397,37 +4575,29 @@ field.
 <td colspan="2" valign="top"><strong>works</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -5475,64 +4645,50 @@ MusicBrainz as one release.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official title of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artistCredit</strong> ⚠️</td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
-
 The main credited artist(s).
-
 <p>⚠️ <strong>DEPRECATED</strong></p>
 <blockquote>
-
 The `artistCredit` field has been renamed to
 `artistCredits`, since it is a list of credits and is referred to in the
 plural form throughout the MusicBrainz documentation. This field is deprecated
 and will be removed in a major release in the future. Use the equivalent
 `artistCredits` field.
-
 </blockquote>
 </td>
 </tr>
@@ -5540,129 +4696,103 @@ and will be removed in a major release in the future. Use the equivalent
 <td colspan="2" valign="top"><strong>artistCredits</strong></td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
-
 The main credited artist(s).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>releaseEvents</strong></td>
 <td valign="top">[<a href="#releaseevent">ReleaseEvent</a>]</td>
 <td>
-
 The release events for this release.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>date</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
-
 The [release date](https://musicbrainz.org/doc/Release/Date)
 is the date in which a release was made available through some sort of
 distribution mechanism.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>country</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The country in which the release was issued.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>asin</strong></td>
 <td valign="top"><a href="#asin">ASIN</a></td>
 <td>
-
 The [Amazon Standard Identification Number](https://musicbrainz.org/doc/ASIN)
 of the release.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>barcode</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The [barcode](https://en.wikipedia.org/wiki/Barcode), if the
 release has one. The most common types found on releases are 12-digit
 [UPCs](https://en.wikipedia.org/wiki/Universal_Product_Code) and 13-digit
 [EANs](https://en.wikipedia.org/wiki/International_Article_Number).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>status</strong></td>
 <td valign="top"><a href="#releasestatus">ReleaseStatus</a></td>
 <td>
-
 The status describes how “official” a release is.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>statusID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `status`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>packaging</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The physical packaging that accompanies the release. See
 the [list of packaging](https://musicbrainz.org/doc/Release/Packaging) for more
 information.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>packagingID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `packaging`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>quality</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Data quality indicates how good the data for a release is.
 It is not a mark of how good or bad the music itself is – for that, use
 [ratings](https://musicbrainz.org/doc/Rating_System).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>media</strong></td>
 <td valign="top">[<a href="#medium">Medium</a>]</td>
 <td>
-
 The media on which the release was distributed.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
-
 A list of artists linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -5679,9 +4809,7 @@ A list of artists linked to this entity.
 <td colspan="2" valign="top"><strong>labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
-
 A list of labels linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -5698,9 +4826,7 @@ A list of labels linked to this entity.
 <td colspan="2" valign="top"><strong>recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
-
 A list of recordings linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -5717,18 +4843,14 @@ A list of recordings linked to this entity.
 <td colspan="2" valign="top"><strong>releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
-
 A list of release groups linked to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
@@ -5745,18 +4867,14 @@ Filter by one or more release group types.
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -5773,9 +4891,7 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -5792,11 +4908,9 @@ A list of tags linked to this entity.
 <td colspan="2" valign="top"><strong>coverArtArchive</strong></td>
 <td valign="top"><a href="#coverartarchiverelease">CoverArtArchiveRelease</a></td>
 <td>
-
 An object containing a list and summary of the cover art images that are
 present for this release from the [Cover Art Archive](https://musicbrainz.org/doc/Cover_Art_Archive).
 This field is provided by the Cover Art Archive extension.
-
 </td>
 </tr>
 </tbody>
@@ -5820,38 +4934,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#releaseedge">ReleaseEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#release">Release</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -5875,28 +4981,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#release">Release</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -5955,64 +5055,50 @@ album – it doesn’t matter how many CDs or editions/versions it had.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official title of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artistCredit</strong> ⚠️</td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
-
 The main credited artist(s).
-
 <p>⚠️ <strong>DEPRECATED</strong></p>
 <blockquote>
-
 The `artistCredit` field has been renamed to
 `artistCredits`, since it is a list of credits and is referred to in the
 plural form throughout the MusicBrainz documentation. This field is deprecated
 and will be removed in a major release in the future. Use the equivalent
 `artistCredits` field.
-
 </blockquote>
 </td>
 </tr>
@@ -6020,69 +5106,55 @@ and will be removed in a major release in the future. Use the equivalent
 <td colspan="2" valign="top"><strong>artistCredits</strong></td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
-
 The main credited artist(s).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>firstReleaseDate</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
-
 The date of the earliest release in the group.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>primaryType</strong></td>
 <td valign="top"><a href="#releasegrouptype">ReleaseGroupType</a></td>
 <td>
-
 The [type](https://musicbrainz.org/doc/Release_Group/Type)
 of a release group describes what kind of releases the release group represents,
 e.g. album, single, soundtrack, compilation, etc. A release group can have a
 “main” type and an unspecified number of additional types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>primaryTypeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `primaryType`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>secondaryTypes</strong></td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Additional [types](https://musicbrainz.org/doc/Release_Group/Type)
 that apply to this release group.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>secondaryTypeIDs</strong></td>
 <td valign="top">[<a href="#mbid">MBID</a>]</td>
 <td>
-
 The MBIDs associated with the values of the `secondaryTypes`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
-
 A list of artists linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -6099,27 +5171,21 @@ A list of artists linked to this entity.
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 A list of releases linked to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">status</td>
 <td valign="top">[<a href="#releasestatus">ReleaseStatus</a>]</td>
 <td>
-
 Filter by one or more release statuses.
-
 </td>
 </tr>
 <tr>
@@ -6136,18 +5202,14 @@ Filter by one or more release statuses.
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -6164,18 +5226,14 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
-
 The rating users have given to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -6192,13 +5250,11 @@ A list of tags linked to this entity.
 <td colspan="2" valign="top"><strong>coverArtArchive</strong></td>
 <td valign="top"><a href="#coverartarchiverelease">CoverArtArchiveRelease</a></td>
 <td>
-
 The cover art for a release in the release group, obtained from the
 [Cover Art Archive](https://musicbrainz.org/doc/Cover_Art_Archive). A
 release in the release group will be chosen as representative of the release
 group.
 This field is provided by the Cover Art Archive extension.
-
 </td>
 </tr>
 </tbody>
@@ -6222,38 +5278,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#releasegroupedge">ReleaseGroupEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#releasegroup">ReleaseGroup</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -6277,28 +5325,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#releasegroup">ReleaseGroup</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -6322,19 +5364,15 @@ A search for MusicBrainz entities using Lucene query syntax.
 <td colspan="2" valign="top"><strong>areas</strong></td>
 <td valign="top"><a href="#areaconnection">AreaConnection</a></td>
 <td>
-
 Search for area entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6351,19 +5389,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
-
 Search for artist entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6380,19 +5414,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
-
 Search for event entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6409,19 +5439,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>instruments</strong></td>
 <td valign="top"><a href="#instrumentconnection">InstrumentConnection</a></td>
 <td>
-
 Search for instrument entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6438,19 +5464,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
-
 Search for label entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6467,19 +5489,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>places</strong></td>
 <td valign="top"><a href="#placeconnection">PlaceConnection</a></td>
 <td>
-
 Search for place entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6496,19 +5514,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
-
 Search for recording entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6525,19 +5539,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 Search for release entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6554,19 +5564,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
-
 Search for release group entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6583,19 +5589,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>series</strong></td>
 <td valign="top"><a href="#seriesconnection">SeriesConnection</a></td>
 <td>
-
 Search for series entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6612,19 +5614,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>works</strong></td>
 <td valign="top"><a href="#workconnection">WorkConnection</a></td>
 <td>
-
 Search for work entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6660,74 +5658,58 @@ theme.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The type primarily describes what type of entity the series
 contains.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -6744,9 +5726,7 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -6780,38 +5760,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#seriesedge">SeriesEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#series">Series</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -6835,28 +5807,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#series">Series</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -6882,18 +5848,14 @@ release, or recording.
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The tag label.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>count</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 How many times this tag has been applied to the entity.
-
 </td>
 </tr>
 </tbody>
@@ -6917,38 +5879,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#tagedge">TagEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#tag">Tag</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -6972,28 +5926,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#tag">Tag</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -7019,56 +5967,44 @@ A track is the way a recording is represented on a particular
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official title of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>position</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The track’s position on the overall release (including all
 tracks from all discs).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>number</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The track number, which may include information about the
 disc or side it appears on, e.g. “A1” or “B3”.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>length</strong></td>
 <td valign="top"><a href="#duration">Duration</a></td>
 <td>
-
 The length of the track.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>recording</strong></td>
 <td valign="top"><a href="#recording">Recording</a></td>
 <td>
-
 The recording that appears on the track.
-
 </td>
 </tr>
 </tbody>
@@ -7094,36 +6030,28 @@ acquired, an entry in another database, etc.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>resource</strong></td>
 <td valign="top"><a href="#urlstring">URLString</a>!</td>
 <td>
-
 The actual URL string.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 </tbody>
@@ -7149,93 +6077,73 @@ more audio recordings.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official title of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>iswcs</strong></td>
 <td valign="top">[<a href="#string">String</a>]</td>
 <td>
-
 A list of [ISWCs](https://musicbrainz.org/doc/ISWC) assigned
 to the work by copyright collecting agencies.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>language</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The language in which the work was originally written.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The type of work.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
-
 A list of artists linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -7252,18 +6160,14 @@ A list of artists linked to this entity.
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -7280,18 +6184,14 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
-
 The rating users have given to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -7325,38 +6225,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#workedge">WorkEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#work">Work</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -7380,28 +6272,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#work">Work</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -7422,25 +6308,19 @@ The image sizes that may be requested at the [Cover Art Archive](https://musicbr
 <tr>
 <td valign="top"><strong>SMALL</strong></td>
 <td>
-
 A maximum dimension of 250px.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>LARGE</strong></td>
 <td>
-
 A maximum dimension of 500px.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>FULL</strong></td>
 <td>
-
 The image’s original dimensions, with no maximum.
-
 </td>
 </tr>
 </tbody>
@@ -7460,130 +6340,103 @@ etc.
 <tr>
 <td valign="top"><strong>ALBUM</strong></td>
 <td>
-
 An album, perhaps better defined as a “Long Play” (LP)
 release, generally consists of previously unreleased material (unless this type
 is combined with secondary types which change that, such as “Compilation”). This
 includes album re-issues, with or without bonus tracks.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>SINGLE</strong></td>
 <td>
-
 A single typically has one main song and possibly a handful
 of additional tracks or remixes of the main track. A single is usually named
 after its main song.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>EP</strong></td>
 <td>
-
 An EP is a so-called “Extended Play” release and often
 contains the letters EP in the title. Generally an EP will be shorter than a
 full length release (an LP or “Long Play”) and the tracks are usually exclusive
 to the EP, in other words the tracks don’t come from a previously issued
 release. EP is fairly difficult to define; usually it should only be assumed
 that a release is an EP if the artist defines it as such.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>OTHER</strong></td>
 <td>
-
 Any release that does not fit any of the other categories.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>BROADCAST</strong></td>
 <td>
-
 An episodic release that was originally broadcast via radio,
 television, or the Internet, including podcasts.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>COMPILATION</strong></td>
 <td>
-
 A compilation is a collection of previously released tracks
 by one or more artists.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>SOUNDTRACK</strong></td>
 <td>
-
 A soundtrack is the musical score to a movie, TV series,
 stage show, computer game, etc.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>SPOKENWORD</strong></td>
 <td>
-
 A non-music spoken word release.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>INTERVIEW</strong></td>
 <td>
-
 An interview release contains an interview, generally with
 an artist.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>AUDIOBOOK</strong></td>
 <td>
-
 An audiobook is a book read by a narrator without music.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>LIVE</strong></td>
 <td>
-
 A release that was recorded live.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>REMIX</strong></td>
 <td>
-
 A release that was (re)mixed from previously released
 material.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>DJMIX</strong></td>
 <td>
-
 A DJ-mix is a sequence of several recordings played one
 after the other, each one modified so that they blend together into a continuous
 flow of music. A DJ mix release requires that the recordings be modified in some
 manner, and the DJ who does this modification is usually (although not always)
 credited in a fairly prominent way.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>MIXTAPE</strong></td>
 <td>
-
 Promotional in nature (but not necessarily free), mixtapes
 and street albums are often released by artists to promote new artists, or
 upcoming studio albums by prominent artists. They are also sometimes used to
@@ -7596,24 +6449,19 @@ significant proportion of new material, including original production or
 original vocals over top of other artists’ instrumentals. They are distinct from
 demos in that they are designed for release directly to the public and fans, not
 to labels.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>DEMO</strong></td>
 <td>
-
 A release that was recorded for limited circulation or
 reference use rather than for general public release.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>NAT</strong></td>
 <td>
-
 A non-album track (special case).
-
 </td>
 </tr>
 </tbody>
@@ -7633,38 +6481,30 @@ bootleg, etc.
 <tr>
 <td valign="top"><strong>OFFICIAL</strong></td>
 <td>
-
 Any release officially sanctioned by the artist and/or their
 record company. (Most releases will fit into this category.)
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>PROMOTION</strong></td>
 <td>
-
 A giveaway release or a release intended to promote an
 upcoming official release, e.g. prerelease albums or releases included with a
 magazine.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>BOOTLEG</strong></td>
 <td>
-
 An unofficial/underground release that was not sanctioned by
 the artist and/or the record company.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>PSEUDORELEASE</strong></td>
 <td>
-
 A pseudo-release is a duplicate release for
 translation/transliteration purposes.
-
 </td>
 </tr>
 </tbody>
@@ -7796,9 +6636,7 @@ An entity in the MusicBrainz schema.
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 </tbody>
@@ -7822,9 +6660,7 @@ An object with an ID
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The id of the object.
-
 </td>
 </tr>
 </tbody>

--- a/test/fixtures/graphbrainz.md
+++ b/test/fixtures/graphbrainz.md
@@ -108,45 +108,35 @@ requests can be made.
 <td colspan="2" valign="top"><strong>lookup</strong></td>
 <td valign="top"><a href="#lookupquery">LookupQuery</a></td>
 <td>
-
 Perform a lookup of a MusicBrainz entity by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>browse</strong></td>
 <td valign="top"><a href="#browsequery">BrowseQuery</a></td>
 <td>
-
 Browse all MusicBrainz entities directly linked to another entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>search</strong></td>
 <td valign="top"><a href="#searchquery">SearchQuery</a></td>
 <td>
-
 Search for MusicBrainz entities using Lucene query syntax.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#node">Node</a></td>
 <td>
-
 Fetches an object given its ID
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">id</td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 </tbody>
@@ -174,60 +164,48 @@ entity will be given as a result – even if the actual name wouldn’t be.
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The aliased name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>sortName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The string to use for the purpose of ordering by name (for
 example, by moving articles like ‘the’ to the end or a person’s last name to
 the front).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>locale</strong></td>
 <td valign="top"><a href="#locale">Locale</a></td>
 <td>
-
 The locale (language and/or country) in which the alias is
 used.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>primary</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
-
 Whether this is the main alias for the entity in the
 specified locale (this could mean the most recent or the most common).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The type or purpose of the alias – whether it is a variant,
 search hint, etc.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 </tbody>
@@ -252,106 +230,84 @@ or settlements (countries, cities, or the like).
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>sortName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The string to use for the purpose of ordering by name (for
 example, by moving articles like ‘the’ to the end or a person’s last name to
 the front).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>isoCodes</strong></td>
 <td valign="top">[<a href="#string">String</a>]</td>
 <td>
-
 [ISO 3166 codes](https://en.wikipedia.org/wiki/ISO_3166) are
 the codes assigned by ISO to countries and subdivisions.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">standard</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Specify the particular ISO standard codes to retrieve.
 Available ISO standards are 3166-1, 3166-2, and 3166-3.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The type of area (country, city, etc. – see the [possible
 values](https://musicbrainz.org/doc/Area)).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
-
 A list of artists linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -368,9 +324,7 @@ A list of artists linked to this entity.
 <td colspan="2" valign="top"><strong>events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
-
 A list of events linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -387,9 +341,7 @@ A list of events linked to this entity.
 <td colspan="2" valign="top"><strong>labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
-
 A list of labels linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -406,9 +358,7 @@ A list of labels linked to this entity.
 <td colspan="2" valign="top"><strong>places</strong></td>
 <td valign="top"><a href="#placeconnection">PlaceConnection</a></td>
 <td>
-
 A list of places linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -425,27 +375,21 @@ A list of places linked to this entity.
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 A list of releases linked to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">status</td>
 <td valign="top">[<a href="#releasestatus">ReleaseStatus</a>]</td>
 <td>
-
 Filter by one or more release statuses.
-
 </td>
 </tr>
 <tr>
@@ -462,18 +406,14 @@ Filter by one or more release statuses.
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -490,9 +430,7 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -526,38 +464,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#areaedge">AreaEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#area">Area</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -581,28 +511,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -630,175 +554,139 @@ even a fictional character.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>sortName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The string to use for the purpose of ordering by name (for
 example, by moving articles like ‘the’ to the end or a person’s last name to
 the front).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>country</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The country with which an artist is primarily identified. It
 is often, but not always, its birth/formation country.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
-
 The area with which an artist is primarily identified. It
 is often, but not always, its birth/formation country.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>beginArea</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
-
 The area in which an artist began their career (or where
 they were born, if the artist is a person).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>endArea</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
-
 The area in which an artist ended their career (or where
 they died, if the artist is a person).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>lifeSpan</strong></td>
 <td valign="top"><a href="#lifespan">LifeSpan</a></td>
 <td>
-
 The begin and end dates of the entity’s existence. Its exact
 meaning depends on the type of entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>gender</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Whether a person or character identifies as male, female, or
 neither. Groups do not have genders.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>genderID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `gender`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Whether an artist is a person, a group, or something else.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>ipis</strong></td>
 <td valign="top">[<a href="#ipi">IPI</a>]</td>
 <td>
-
 List of [Interested Parties Information](https://musicbrainz.org/doc/IPI)
 (IPI) codes for the artist.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>isnis</strong></td>
 <td valign="top">[<a href="#isni">ISNI</a>]</td>
 <td>
-
 List of [International Standard Name Identifier](https://musicbrainz.org/doc/ISNI)
 (ISNI) codes for the artist.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
-
 A list of recordings linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -815,27 +703,21 @@ A list of recordings linked to this entity.
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 A list of releases linked to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">status</td>
 <td valign="top">[<a href="#releasestatus">ReleaseStatus</a>]</td>
 <td>
-
 Filter by one or more release statuses.
-
 </td>
 </tr>
 <tr>
@@ -852,18 +734,14 @@ Filter by one or more release statuses.
 <td colspan="2" valign="top"><strong>releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
-
 A list of release groups linked to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
@@ -880,9 +758,7 @@ Filter by one or more release group types.
 <td colspan="2" valign="top"><strong>works</strong></td>
 <td valign="top"><a href="#workconnection">WorkConnection</a></td>
 <td>
-
 A list of works linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -899,18 +775,14 @@ A list of works linked to this entity.
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -927,18 +799,14 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
-
 The rating users have given to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -972,38 +840,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#artistedge">ArtistEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#artist">Artist</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -1031,30 +891,24 @@ track, etc., and join phrases between them.
 <td colspan="2" valign="top"><strong>artist</strong></td>
 <td valign="top"><a href="#artist">Artist</a></td>
 <td>
-
 The entity representing the artist referenced in the
 credits.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The name of the artist as credited in the specific release,
 track, etc.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>joinPhrase</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Join phrases might include words and/or punctuation to
 separate artist names as they appear on the release, track, etc.
-
 </td>
 </tr>
 </tbody>
@@ -1078,28 +932,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#artist">Artist</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -1124,18 +972,14 @@ entity.
 <td colspan="2" valign="top"><strong>areas</strong></td>
 <td valign="top"><a href="#areaconnection">AreaConnection</a></td>
 <td>
-
 Browse area entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
@@ -1152,63 +996,49 @@ The MBID of a collection in which the entity is found.
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
-
 Browse artist entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">area</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an area to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">recording</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a recording to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">release</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a release to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">releaseGroup</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a release group to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">work</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a work to which the entity is linked.
-
 </td>
 </tr>
 <tr>
@@ -1225,99 +1055,77 @@ The MBID of a work to which the entity is linked.
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 Browse collection entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">area</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an area to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">artist</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an artist to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">editor</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The username of the editor who created the collection.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">event</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an event to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">label</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a label to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">place</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a place to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">recording</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a recording to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">release</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a release to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">releaseGroup</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a release group to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">work</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a work to which the entity is linked.
-
 </td>
 </tr>
 <tr>
@@ -1334,45 +1142,35 @@ The MBID of a work to which the entity is linked.
 <td colspan="2" valign="top"><strong>events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
-
 Browse event entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">area</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an area to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">artist</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an artist to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">place</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a place to which the entity is linked.
-
 </td>
 </tr>
 <tr>
@@ -1389,36 +1187,28 @@ The MBID of a place to which the entity is linked.
 <td colspan="2" valign="top"><strong>labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
-
 Browse label entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">area</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an area to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">release</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a release to which the entity is linked.
-
 </td>
 </tr>
 <tr>
@@ -1435,27 +1225,21 @@ The MBID of a release to which the entity is linked.
 <td colspan="2" valign="top"><strong>places</strong></td>
 <td valign="top"><a href="#placeconnection">PlaceConnection</a></td>
 <td>
-
 Browse place entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">area</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an area to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
@@ -1472,46 +1256,36 @@ The MBID of a collection in which the entity is found.
 <td colspan="2" valign="top"><strong>recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
-
 Browse recording entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">artist</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an artist to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">isrc</td>
 <td valign="top"><a href="#isrc">ISRC</a></td>
 <td>
-
 The [International Standard Recording Code](https://musicbrainz.org/doc/ISRC)
 (ISRC) of the recording.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">release</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a release to which the entity is linked.
-
 </td>
 </tr>
 <tr>
@@ -1528,110 +1302,86 @@ The MBID of a release to which the entity is linked.
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 Browse release entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">area</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an area to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">artist</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an artist to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">discID</td>
 <td valign="top"><a href="#discid">DiscID</a></td>
 <td>
-
 A [disc ID](https://musicbrainz.org/doc/Disc_ID)
 associated with the release.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">label</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a label to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">recording</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a recording to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">releaseGroup</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a release group to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">track</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a track that is included in the release.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">trackArtist</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an artist that appears on a track in the
 release, but is not included in the credits for the release itself.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">status</td>
 <td valign="top">[<a href="#releasestatus">ReleaseStatus</a>]</td>
 <td>
-
 Filter by one or more release statuses.
-
 </td>
 </tr>
 <tr>
@@ -1648,45 +1398,35 @@ Filter by one or more release statuses.
 <td colspan="2" valign="top"><strong>releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
-
 Browse release group entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">artist</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an artist to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">release</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a release to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
@@ -1703,37 +1443,29 @@ Filter by one or more release group types.
 <td colspan="2" valign="top"><strong>works</strong></td>
 <td valign="top"><a href="#workconnection">WorkConnection</a></td>
 <td>
-
 Browse work entities linked to the given arguments.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">artist</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of an artist to which the entity is linked.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">collection</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of a collection in which the entity is found.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">iswc</td>
 <td valign="top"><a href="#iswc">ISWC</a></td>
 <td>
-
 The [International Standard Musical Work Code](https://musicbrainz.org/doc/ISWC)
 (ISWC) of the work.
-
 </td>
 </tr>
 <tr>
@@ -1768,73 +1500,57 @@ lists of entities that users can create.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>editor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The username of the editor who created the collection.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>entityType</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The type of entity listed in the collection.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The type of collection.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>areas</strong></td>
 <td valign="top"><a href="#areaconnection">AreaConnection</a></td>
 <td>
-
 The list of areas found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -1851,9 +1567,7 @@ The list of areas found in this collection.
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
-
 The list of artists found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -1870,9 +1584,7 @@ The list of artists found in this collection.
 <td colspan="2" valign="top"><strong>events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
-
 The list of events found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -1889,9 +1601,7 @@ The list of events found in this collection.
 <td colspan="2" valign="top"><strong>instruments</strong></td>
 <td valign="top"><a href="#instrumentconnection">InstrumentConnection</a></td>
 <td>
-
 The list of instruments found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -1908,9 +1618,7 @@ The list of instruments found in this collection.
 <td colspan="2" valign="top"><strong>labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
-
 The list of labels found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -1927,9 +1635,7 @@ The list of labels found in this collection.
 <td colspan="2" valign="top"><strong>places</strong></td>
 <td valign="top"><a href="#placeconnection">PlaceConnection</a></td>
 <td>
-
 The list of places found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -1946,9 +1652,7 @@ The list of places found in this collection.
 <td colspan="2" valign="top"><strong>recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
-
 The list of recordings found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -1965,27 +1669,21 @@ The list of recordings found in this collection.
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 The list of releases found in this collection.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">status</td>
 <td valign="top">[<a href="#releasestatus">ReleaseStatus</a>]</td>
 <td>
-
 Filter by one or more release statuses.
-
 </td>
 </tr>
 <tr>
@@ -2002,18 +1700,14 @@ Filter by one or more release statuses.
 <td colspan="2" valign="top"><strong>releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
-
 The list of release groups found in this collection.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
@@ -2030,9 +1724,7 @@ Filter by one or more release group types.
 <td colspan="2" valign="top"><strong>series</strong></td>
 <td valign="top"><a href="#seriesconnection">SeriesConnection</a></td>
 <td>
-
 The list of series found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -2049,9 +1741,7 @@ The list of series found in this collection.
 <td colspan="2" valign="top"><strong>works</strong></td>
 <td valign="top"><a href="#workconnection">WorkConnection</a></td>
 <td>
-
 The list of works found in this collection.
-
 </td>
 </tr>
 <tr>
@@ -2085,38 +1775,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#collectionedge">CollectionEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#collection">Collection</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -2140,28 +1822,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#collection">Collection</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -2185,18 +1861,14 @@ Geographic coordinates described with latitude and longitude.
 <td colspan="2" valign="top"><strong>latitude</strong></td>
 <td valign="top"><a href="#degrees">Degrees</a></td>
 <td>
-
 The north–south position of a point on the Earth’s surface.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>longitude</strong></td>
 <td valign="top"><a href="#degrees">Degrees</a></td>
 <td>
-
 The east–west position of a point on the Earth’s surface.
-
 </td>
 </tr>
 </tbody>
@@ -2221,54 +1893,42 @@ particular [disc ID](https://musicbrainz.org/doc/Disc_ID).
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>discID</strong></td>
 <td valign="top"><a href="#discid">DiscID</a>!</td>
 <td>
-
 The [disc ID](https://musicbrainz.org/doc/Disc_ID) of this disc.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>offsetCount</strong></td>
 <td valign="top"><a href="#int">Int</a>!</td>
 <td>
-
 The number of offsets (tracks) on the disc.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>offsets</strong></td>
 <td valign="top">[<a href="#int">Int</a>]</td>
 <td>
-
 The sector offset of each track on the disc.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>sectors</strong></td>
 <td valign="top"><a href="#int">Int</a>!</td>
 <td>
-
 The sector offset of the lead-out (the end of the disc).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 The list of releases linked to this disc ID.
-
 </td>
 </tr>
 <tr>
@@ -2304,122 +1964,96 @@ Generally this means live performances, like concerts and festivals.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>lifeSpan</strong></td>
 <td valign="top"><a href="#lifespan">LifeSpan</a></td>
 <td>
-
 The begin and end dates of the entity’s existence. Its exact
 meaning depends on the type of entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>time</strong></td>
 <td valign="top"><a href="#time">Time</a></td>
 <td>
-
 The start time of the event.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cancelled</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
-
 Whether or not the event took place.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>setlist</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A list of songs performed, optionally including links to
 artists and works. See the [setlist documentation](https://musicbrainz.org/doc/Event/Setlist)
 for syntax and examples.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 What kind of event the event is, e.g. concert, festival, etc.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -2436,18 +2070,14 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
-
 The rating users have given to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -2481,38 +2111,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#eventedge">EventEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#event">Event</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -2536,28 +2158,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#event">Event</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -2583,95 +2199,75 @@ used in relationships between two other entities.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>description</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A brief description of the main characteristics of the
 instrument.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The type categorises the instrument by the way the sound is
 created, similar to the [Hornbostel-Sachs](https://en.wikipedia.org/wiki/Hornbostel%E2%80%93Sachs)
 classification.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -2688,9 +2284,7 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -2724,38 +2318,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#instrumentedge">InstrumentEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#instrument">Instrument</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -2779,28 +2365,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#instrument">Instrument</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -2826,152 +2406,120 @@ represent a record company.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>sortName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The string to use for the purpose of ordering by name (for
 example, by moving articles like ‘the’ to the end or a person’s last name to
 the front).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>country</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The country of origin for the label.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
-
 The area in which the label is based.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>lifeSpan</strong></td>
 <td valign="top"><a href="#lifespan">LifeSpan</a></td>
 <td>
-
 The begin and end dates of the entity’s existence. Its exact
 meaning depends on the type of entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>labelCode</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The [“LC” code](https://musicbrainz.org/doc/Label/Label_Code)
 of the label.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>ipis</strong></td>
 <td valign="top">[<a href="#ipi">IPI</a>]</td>
 <td>
-
 List of [Interested Parties Information](https://musicbrainz.org/doc/IPI)
 codes for the label.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A type describing the main activity of the label, e.g.
 imprint, production, distributor, rights society, etc.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 A list of releases linked to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">status</td>
 <td valign="top">[<a href="#releasestatus">ReleaseStatus</a>]</td>
 <td>
-
 Filter by one or more release statuses.
-
 </td>
 </tr>
 <tr>
@@ -2988,18 +2536,14 @@ Filter by one or more release statuses.
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -3016,18 +2560,14 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
-
 The rating users have given to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -3061,38 +2601,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#labeledge">LabelEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#label">Label</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -3116,28 +2648,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#label">Label</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -3162,27 +2688,21 @@ lifetime, including whether it has ended (even if the date is unknown).
 <td colspan="2" valign="top"><strong>begin</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
-
 The start date of the entity’s life span.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>end</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
-
 The end date of the entity’s life span.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>ended</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
-
 Whether or not the entity’s life span has ended.
-
 </td>
 </tr>
 </tbody>
@@ -3206,262 +2726,204 @@ A lookup of an individual MusicBrainz entity by its MBID.
 <td colspan="2" valign="top"><strong>area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
-
 Look up a specific area by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artist</strong></td>
 <td valign="top"><a href="#artist">Artist</a></td>
 <td>
-
 Look up a specific artist by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collection</strong></td>
 <td valign="top"><a href="#collection">Collection</a></td>
 <td>
-
 Look up a specific collection by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disc</strong></td>
 <td valign="top"><a href="#disc">Disc</a></td>
 <td>
-
 Look up a specific physical disc by its disc ID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">discID</td>
 <td valign="top"><a href="#discid">DiscID</a>!</td>
 <td>
-
 The [disc ID](https://musicbrainz.org/doc/Disc_ID)
 of the disc.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>event</strong></td>
 <td valign="top"><a href="#event">Event</a></td>
 <td>
-
 Look up a specific event by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>instrument</strong></td>
 <td valign="top"><a href="#instrument">Instrument</a></td>
 <td>
-
 Look up a specific instrument by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>label</strong></td>
 <td valign="top"><a href="#label">Label</a></td>
 <td>
-
 Look up a specific label by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>place</strong></td>
 <td valign="top"><a href="#place">Place</a></td>
 <td>
-
 Look up a specific place by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>recording</strong></td>
 <td valign="top"><a href="#recording">Recording</a></td>
 <td>
-
 Look up a specific recording by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>release</strong></td>
 <td valign="top"><a href="#release">Release</a></td>
 <td>
-
 Look up a specific release by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>releaseGroup</strong></td>
 <td valign="top"><a href="#releasegroup">ReleaseGroup</a></td>
 <td>
-
 Look up a specific release group by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>series</strong></td>
 <td valign="top"><a href="#series">Series</a></td>
 <td>
-
 Look up a specific series by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>url</strong></td>
 <td valign="top"><a href="#url">URL</a></td>
 <td>
-
 Look up a specific URL by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">resource</td>
 <td valign="top"><a href="#urlstring">URLString</a></td>
 <td>
-
 The web address of the URL entity to look up.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>work</strong></td>
 <td valign="top"><a href="#work">Work</a></td>
 <td>
-
 Look up a specific work by its MBID.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">mbid</td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 </tbody>
@@ -3489,66 +2951,52 @@ cassette) and can optionally also have a title.
 <td colspan="2" valign="top"><strong>title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The title of this particular medium.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>format</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The [format](https://musicbrainz.org/doc/Release/Format) of
 the medium (e.g. CD, DVD, vinyl, cassette).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>formatID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `format`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>position</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The order of this medium in the release (for example, in a
 multi-disc release).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>trackCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The number of audio tracks on this medium.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>discs</strong></td>
 <td valign="top">[<a href="#disc">Disc</a>]</td>
 <td>
-
 A list of physical discs and their disc IDs for this medium.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>tracks</strong></td>
 <td valign="top">[<a href="#track">Track</a>]</td>
 <td>
-
 The list of tracks on the given media.
-
 </td>
 </tr>
 </tbody>
@@ -3572,36 +3020,28 @@ Information about pagination in a connection.
 <td colspan="2" valign="top"><strong>hasNextPage</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a>!</td>
 <td>
-
 When paginating forwards, are there more items?
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>hasPreviousPage</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a>!</td>
 <td>
-
 When paginating backwards, are there more items?
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>startCursor</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 When paginating backwards, the cursor to continue.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>endCursor</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 When paginating forwards, the cursor to continue.
-
 </td>
 </tr>
 </tbody>
@@ -3626,114 +3066,90 @@ or other place where music is performed, recorded, engineered, etc.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>address</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The address describes the location of the place using the
 standard addressing format for the country it is located in.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
-
 The area entity representing the area, such as the city, in
 which the place is located.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>coordinates</strong></td>
 <td valign="top"><a href="#coordinates">Coordinates</a></td>
 <td>
-
 The geographic coordinates of the place.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>lifeSpan</strong></td>
 <td valign="top"><a href="#lifespan">LifeSpan</a></td>
 <td>
-
 The begin and end dates of the entity’s existence. Its exact
 meaning depends on the type of entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The type categorises the place based on its primary
 function.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
-
 A list of events linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -3750,18 +3166,14 @@ A list of events linked to this entity.
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -3778,9 +3190,7 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -3814,38 +3224,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#placeedge">PlaceEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#place">Place</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -3869,28 +3271,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#place">Place</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -3917,18 +3313,14 @@ for the entity.
 <td colspan="2" valign="top"><strong>voteCount</strong></td>
 <td valign="top"><a href="#int">Int</a>!</td>
 <td>
-
 The number of votes that have contributed to the rating.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>value</strong></td>
 <td valign="top"><a href="#float">Float</a></td>
 <td>
-
 The average rating value based on the aggregated votes.
-
 </td>
 </tr>
 </tbody>
@@ -3963,64 +3355,50 @@ or mixing.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official title of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artistCredit</strong> ⚠️</td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
-
 The main credited artist(s).
-
 <p>⚠️ <strong>DEPRECATED</strong></p>
 <blockquote>
-
 The `artistCredit` field has been renamed to
 `artistCredits`, since it is a list of credits and is referred to in the
 plural form throughout the MusicBrainz documentation. This field is deprecated
 and will be removed in a major release in the future. Use the equivalent
 `artistCredits` field.
-
 </blockquote>
 </td>
 </tr>
@@ -4028,47 +3406,37 @@ and will be removed in a major release in the future. Use the equivalent
 <td colspan="2" valign="top"><strong>artistCredits</strong></td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
-
 The main credited artist(s).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>isrcs</strong></td>
 <td valign="top">[<a href="#isrc">ISRC</a>]</td>
 <td>
-
 A list of [International Standard Recording Codes](https://musicbrainz.org/doc/ISRC)
 (ISRCs) for this recording.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>length</strong></td>
 <td valign="top"><a href="#duration">Duration</a></td>
 <td>
-
 An approximation to the length of the recording, calculated
 from the lengths of the tracks using it.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>video</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
-
 Whether this is a video recording.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
-
 A list of artists linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -4085,27 +3453,21 @@ A list of artists linked to this entity.
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 A list of releases linked to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">status</td>
 <td valign="top">[<a href="#releasestatus">ReleaseStatus</a>]</td>
 <td>
-
 Filter by one or more release statuses.
-
 </td>
 </tr>
 <tr>
@@ -4122,18 +3484,14 @@ Filter by one or more release statuses.
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -4150,18 +3508,14 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
-
 The rating users have given to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -4195,38 +3549,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#recordingedge">RecordingEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#recording">Recording</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -4250,28 +3596,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#recording">Recording</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -4297,105 +3637,83 @@ other and to URLs outside MusicBrainz.
 <td colspan="2" valign="top"><strong>target</strong></td>
 <td valign="top"><a href="#entity">Entity</a>!</td>
 <td>
-
 The target entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>direction</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The direction of the relationship.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>targetType</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The type of entity on the receiving end of the relationship.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>sourceCredit</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 How the source entity was actually credited, if different
 from its main (performance) name.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>targetCredit</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 How the target entity was actually credited, if different
 from its main (performance) name.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>begin</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
-
 The date on which the relationship became applicable.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>end</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
-
 The date on which the relationship became no longer applicable.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>ended</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
-
 Whether the relationship still applies.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>attributes</strong></td>
 <td valign="top">[<a href="#string">String</a>]</td>
 <td>
-
 Attributes which modify the relationship. There is a [list
 of all attributes](https://musicbrainz.org/relationship-attributes), but the
 attributes which are available, and how they should be used, depends on the
 relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The type of relationship.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 </tbody>
@@ -4419,38 +3737,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#relationshipedge">RelationshipEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#relationship">Relationship</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -4474,28 +3784,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#relationship">Relationship</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -4519,37 +3823,29 @@ Lists of entity relationships for each entity type.
 <td colspan="2" valign="top"><strong>areas</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -4576,37 +3872,29 @@ field.
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -4633,37 +3921,29 @@ field.
 <td colspan="2" valign="top"><strong>events</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -4690,37 +3970,29 @@ field.
 <td colspan="2" valign="top"><strong>instruments</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -4747,37 +4019,29 @@ field.
 <td colspan="2" valign="top"><strong>labels</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -4804,37 +4068,29 @@ field.
 <td colspan="2" valign="top"><strong>places</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -4861,37 +4117,29 @@ field.
 <td colspan="2" valign="top"><strong>recordings</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -4918,37 +4166,29 @@ field.
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -4975,37 +4215,29 @@ field.
 <td colspan="2" valign="top"><strong>releaseGroups</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -5032,37 +4264,29 @@ field.
 <td colspan="2" valign="top"><strong>series</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -5089,37 +4313,29 @@ field.
 <td colspan="2" valign="top"><strong>urls</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -5146,37 +4362,29 @@ field.
 <td colspan="2" valign="top"><strong>works</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
-
 A list of relationships between these two entity types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">direction</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship direction.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Filter by the relationship type.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">typeID</td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
@@ -5224,64 +4432,50 @@ MusicBrainz as one release.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official title of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artistCredit</strong> ⚠️</td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
-
 The main credited artist(s).
-
 <p>⚠️ <strong>DEPRECATED</strong></p>
 <blockquote>
-
 The `artistCredit` field has been renamed to
 `artistCredits`, since it is a list of credits and is referred to in the
 plural form throughout the MusicBrainz documentation. This field is deprecated
 and will be removed in a major release in the future. Use the equivalent
 `artistCredits` field.
-
 </blockquote>
 </td>
 </tr>
@@ -5289,129 +4483,103 @@ and will be removed in a major release in the future. Use the equivalent
 <td colspan="2" valign="top"><strong>artistCredits</strong></td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
-
 The main credited artist(s).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>releaseEvents</strong></td>
 <td valign="top">[<a href="#releaseevent">ReleaseEvent</a>]</td>
 <td>
-
 The release events for this release.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>date</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
-
 The [release date](https://musicbrainz.org/doc/Release/Date)
 is the date in which a release was made available through some sort of
 distribution mechanism.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>country</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The country in which the release was issued.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>asin</strong></td>
 <td valign="top"><a href="#asin">ASIN</a></td>
 <td>
-
 The [Amazon Standard Identification Number](https://musicbrainz.org/doc/ASIN)
 of the release.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>barcode</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The [barcode](https://en.wikipedia.org/wiki/Barcode), if the
 release has one. The most common types found on releases are 12-digit
 [UPCs](https://en.wikipedia.org/wiki/Universal_Product_Code) and 13-digit
 [EANs](https://en.wikipedia.org/wiki/International_Article_Number).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>status</strong></td>
 <td valign="top"><a href="#releasestatus">ReleaseStatus</a></td>
 <td>
-
 The status describes how “official” a release is.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>statusID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `status`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>packaging</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The physical packaging that accompanies the release. See
 the [list of packaging](https://musicbrainz.org/doc/Release/Packaging) for more
 information.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>packagingID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `packaging`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>quality</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 Data quality indicates how good the data for a release is.
 It is not a mark of how good or bad the music itself is – for that, use
 [ratings](https://musicbrainz.org/doc/Rating_System).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>media</strong></td>
 <td valign="top">[<a href="#medium">Medium</a>]</td>
 <td>
-
 The media on which the release was distributed.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
-
 A list of artists linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -5428,9 +4596,7 @@ A list of artists linked to this entity.
 <td colspan="2" valign="top"><strong>labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
-
 A list of labels linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -5447,9 +4613,7 @@ A list of labels linked to this entity.
 <td colspan="2" valign="top"><strong>recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
-
 A list of recordings linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -5466,18 +4630,14 @@ A list of recordings linked to this entity.
 <td colspan="2" valign="top"><strong>releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
-
 A list of release groups linked to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
@@ -5494,18 +4654,14 @@ Filter by one or more release group types.
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -5522,9 +4678,7 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -5558,38 +4712,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#releaseedge">ReleaseEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#release">Release</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -5613,28 +4759,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#release">Release</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -5693,64 +4833,50 @@ album – it doesn’t matter how many CDs or editions/versions it had.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official title of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artistCredit</strong> ⚠️</td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
-
 The main credited artist(s).
-
 <p>⚠️ <strong>DEPRECATED</strong></p>
 <blockquote>
-
 The `artistCredit` field has been renamed to
 `artistCredits`, since it is a list of credits and is referred to in the
 plural form throughout the MusicBrainz documentation. This field is deprecated
 and will be removed in a major release in the future. Use the equivalent
 `artistCredits` field.
-
 </blockquote>
 </td>
 </tr>
@@ -5758,69 +4884,55 @@ and will be removed in a major release in the future. Use the equivalent
 <td colspan="2" valign="top"><strong>artistCredits</strong></td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
-
 The main credited artist(s).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>firstReleaseDate</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
-
 The date of the earliest release in the group.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>primaryType</strong></td>
 <td valign="top"><a href="#releasegrouptype">ReleaseGroupType</a></td>
 <td>
-
 The [type](https://musicbrainz.org/doc/Release_Group/Type)
 of a release group describes what kind of releases the release group represents,
 e.g. album, single, soundtrack, compilation, etc. A release group can have a
 “main” type and an unspecified number of additional types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>primaryTypeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `primaryType`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>secondaryTypes</strong></td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Additional [types](https://musicbrainz.org/doc/Release_Group/Type)
 that apply to this release group.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>secondaryTypeIDs</strong></td>
 <td valign="top">[<a href="#mbid">MBID</a>]</td>
 <td>
-
 The MBIDs associated with the values of the `secondaryTypes`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
-
 A list of artists linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -5837,27 +4949,21 @@ A list of artists linked to this entity.
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 A list of releases linked to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
-
 Filter by one or more release group types.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">status</td>
 <td valign="top">[<a href="#releasestatus">ReleaseStatus</a>]</td>
 <td>
-
 Filter by one or more release statuses.
-
 </td>
 </tr>
 <tr>
@@ -5874,18 +4980,14 @@ Filter by one or more release statuses.
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -5902,18 +5004,14 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
-
 The rating users have given to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -5947,38 +5045,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#releasegroupedge">ReleaseGroupEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#releasegroup">ReleaseGroup</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -6002,28 +5092,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#releasegroup">ReleaseGroup</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -6047,19 +5131,15 @@ A search for MusicBrainz entities using Lucene query syntax.
 <td colspan="2" valign="top"><strong>areas</strong></td>
 <td valign="top"><a href="#areaconnection">AreaConnection</a></td>
 <td>
-
 Search for area entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6076,19 +5156,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
-
 Search for artist entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6105,19 +5181,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
-
 Search for event entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6134,19 +5206,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>instruments</strong></td>
 <td valign="top"><a href="#instrumentconnection">InstrumentConnection</a></td>
 <td>
-
 Search for instrument entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6163,19 +5231,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
-
 Search for label entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6192,19 +5256,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>places</strong></td>
 <td valign="top"><a href="#placeconnection">PlaceConnection</a></td>
 <td>
-
 Search for place entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6221,19 +5281,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
-
 Search for recording entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6250,19 +5306,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
-
 Search for release entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6279,19 +5331,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
-
 Search for release group entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6308,19 +5356,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>series</strong></td>
 <td valign="top"><a href="#seriesconnection">SeriesConnection</a></td>
 <td>
-
 Search for series entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6337,19 +5381,15 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td colspan="2" valign="top"><strong>works</strong></td>
 <td valign="top"><a href="#workconnection">WorkConnection</a></td>
 <td>
-
 Search for work entities matching the given query.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">query</td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The query terms, in Lucene search syntax. See [examples
 and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search).
-
 </td>
 </tr>
 <tr>
@@ -6385,74 +5425,58 @@ theme.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official name of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The type primarily describes what type of entity the series
 contains.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -6469,9 +5493,7 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -6505,38 +5527,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#seriesedge">SeriesEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#series">Series</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -6560,28 +5574,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#series">Series</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -6607,18 +5615,14 @@ release, or recording.
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 The tag label.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>count</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 How many times this tag has been applied to the entity.
-
 </td>
 </tr>
 </tbody>
@@ -6642,38 +5646,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#tagedge">TagEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#tag">Tag</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -6697,28 +5693,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#tag">Tag</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -6744,56 +5734,44 @@ A track is the way a recording is represented on a particular
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official title of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>position</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The track’s position on the overall release (including all
 tracks from all discs).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>number</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The track number, which may include information about the
 disc or side it appears on, e.g. “A1” or “B3”.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>length</strong></td>
 <td valign="top"><a href="#duration">Duration</a></td>
 <td>
-
 The length of the track.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>recording</strong></td>
 <td valign="top"><a href="#recording">Recording</a></td>
 <td>
-
 The recording that appears on the track.
-
 </td>
 </tr>
 </tbody>
@@ -6819,36 +5797,28 @@ acquired, an entry in another database, etc.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>resource</strong></td>
 <td valign="top"><a href="#urlstring">URLString</a>!</td>
 <td>
-
 The actual URL string.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 </tbody>
@@ -6874,93 +5844,73 @@ more audio recordings.
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The ID of an object
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The official title of the entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 A comment used to help distinguish identically named entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
-
 [Aliases](https://musicbrainz.org/doc/Aliases) are used to store
 alternate names or misspellings.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>iswcs</strong></td>
 <td valign="top">[<a href="#string">String</a>]</td>
 <td>
-
 A list of [ISWCs](https://musicbrainz.org/doc/ISWC) assigned
 to the work by copyright collecting agencies.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>language</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The language in which the work was originally written.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
-
 The type of work.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
-
 The MBID associated with the value of the `type`
 field.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
-
 A list of artists linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -6977,18 +5927,14 @@ A list of artists linked to this entity.
 <td colspan="2" valign="top"><strong>relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
-
 Relationships between this entity and other entitites.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
-
 A list of collections containing this entity.
-
 </td>
 </tr>
 <tr>
@@ -7005,18 +5951,14 @@ A list of collections containing this entity.
 <td colspan="2" valign="top"><strong>rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
-
 The rating users have given to this entity.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
-
 A list of tags linked to this entity.
-
 </td>
 </tr>
 <tr>
@@ -7050,38 +5992,30 @@ A connection to a list of items.
 <td colspan="2" valign="top"><strong>pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
-
 Information to aid in pagination.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>edges</strong></td>
 <td valign="top">[<a href="#workedge">WorkEdge</a>]</td>
 <td>
-
 A list of edges.
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nodes</strong></td>
 <td valign="top">[<a href="#work">Work</a>]</td>
 <td>
-
 A list of nodes in the connection (without going through the
 `edges` field).
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 A count of the total number of items in this connection,
 ignoring pagination.
-
 </td>
 </tr>
 </tbody>
@@ -7105,28 +6039,22 @@ An edge in a connection.
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#work">Work</a></td>
 <td>
-
 The item at the end of the edge
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
-
 A cursor for use in pagination
-
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
-
 The relevancy score (0–100) assigned by the search engine, if
 these results were found through a search.
-
 </td>
 </tr>
 </tbody>
@@ -7148,130 +6076,103 @@ etc.
 <tr>
 <td valign="top"><strong>ALBUM</strong></td>
 <td>
-
 An album, perhaps better defined as a “Long Play” (LP)
 release, generally consists of previously unreleased material (unless this type
 is combined with secondary types which change that, such as “Compilation”). This
 includes album re-issues, with or without bonus tracks.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>SINGLE</strong></td>
 <td>
-
 A single typically has one main song and possibly a handful
 of additional tracks or remixes of the main track. A single is usually named
 after its main song.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>EP</strong></td>
 <td>
-
 An EP is a so-called “Extended Play” release and often
 contains the letters EP in the title. Generally an EP will be shorter than a
 full length release (an LP or “Long Play”) and the tracks are usually exclusive
 to the EP, in other words the tracks don’t come from a previously issued
 release. EP is fairly difficult to define; usually it should only be assumed
 that a release is an EP if the artist defines it as such.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>OTHER</strong></td>
 <td>
-
 Any release that does not fit any of the other categories.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>BROADCAST</strong></td>
 <td>
-
 An episodic release that was originally broadcast via radio,
 television, or the Internet, including podcasts.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>COMPILATION</strong></td>
 <td>
-
 A compilation is a collection of previously released tracks
 by one or more artists.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>SOUNDTRACK</strong></td>
 <td>
-
 A soundtrack is the musical score to a movie, TV series,
 stage show, computer game, etc.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>SPOKENWORD</strong></td>
 <td>
-
 A non-music spoken word release.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>INTERVIEW</strong></td>
 <td>
-
 An interview release contains an interview, generally with
 an artist.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>AUDIOBOOK</strong></td>
 <td>
-
 An audiobook is a book read by a narrator without music.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>LIVE</strong></td>
 <td>
-
 A release that was recorded live.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>REMIX</strong></td>
 <td>
-
 A release that was (re)mixed from previously released
 material.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>DJMIX</strong></td>
 <td>
-
 A DJ-mix is a sequence of several recordings played one
 after the other, each one modified so that they blend together into a continuous
 flow of music. A DJ mix release requires that the recordings be modified in some
 manner, and the DJ who does this modification is usually (although not always)
 credited in a fairly prominent way.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>MIXTAPE</strong></td>
 <td>
-
 Promotional in nature (but not necessarily free), mixtapes
 and street albums are often released by artists to promote new artists, or
 upcoming studio albums by prominent artists. They are also sometimes used to
@@ -7284,24 +6185,19 @@ significant proportion of new material, including original production or
 original vocals over top of other artists’ instrumentals. They are distinct from
 demos in that they are designed for release directly to the public and fans, not
 to labels.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>DEMO</strong></td>
 <td>
-
 A release that was recorded for limited circulation or
 reference use rather than for general public release.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>NAT</strong></td>
 <td>
-
 A non-album track (special case).
-
 </td>
 </tr>
 </tbody>
@@ -7321,38 +6217,30 @@ bootleg, etc.
 <tr>
 <td valign="top"><strong>OFFICIAL</strong></td>
 <td>
-
 Any release officially sanctioned by the artist and/or their
 record company. (Most releases will fit into this category.)
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>PROMOTION</strong></td>
 <td>
-
 A giveaway release or a release intended to promote an
 upcoming official release, e.g. prerelease albums or releases included with a
 magazine.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>BOOTLEG</strong></td>
 <td>
-
 An unofficial/underground release that was not sanctioned by
 the artist and/or the record company.
-
 </td>
 </tr>
 <tr>
 <td valign="top"><strong>PSEUDORELEASE</strong></td>
 <td>
-
 A pseudo-release is a duplicate release for
 translation/transliteration purposes.
-
 </td>
 </tr>
 </tbody>
@@ -7484,9 +6372,7 @@ An entity in the MusicBrainz schema.
 <td colspan="2" valign="top"><strong>mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
-
 The MBID of the entity.
-
 </td>
 </tr>
 </tbody>
@@ -7510,9 +6396,7 @@ An object with an ID
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
-
 The id of the object.
-
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
…ring

## Errors while rendering
Some markdown engines have errors when trying to render html tables that have new lines in them. Specfically, new lines in <td> element cause an issue By removing them we are fixing this issue. @exogen Are you the right person to review this?