### PR TITLE
loadSchemaJSON.js: Sync with npm run format

### DIFF
--- a/src/loadSchemaJSON.js
+++ b/src/loadSchemaJSON.js
@@ -9,10 +9,8 @@ const DEFAULT_GRAPHQL = graphql
 
 function readFile(filename) {
   return new Promise((resolve, reject) => {
-    fs.readFile(
-      filename,
-      'utf8',
-      (err, data) => (err ? reject(err) : resolve(data))
+    fs.readFile(filename, 'utf8', (err, data) =>
+      err ? reject(err) : resolve(data)
     )
   })
 }


### PR DESCRIPTION
`npm run format` has a tiny diff

(I have a subsequent issue for normalizing styling / prettier, so wanted to get this out of the way)