### PR TITLE
Replace reference to deprecated introspectionQuery

### DIFF
--- a/src/loadSchemaJSON.js
+++ b/src/loadSchemaJSON.js
@@ -20,9 +20,11 @@ function readFile(filename) {
 function schemaToJSON(schema, options) {
   options = options || {}
   const graphql = options.graphql || DEFAULT_GRAPHQL
-  return graphql.graphql(schema, graphql.introspectionQuery).then(result => {
-    return result.data
-  })
+  return graphql
+    .graphql(schema, graphql.getIntrospectionQuery())
+    .then(result => {
+      return result.data
+    })
 }
 
 function fetchSchemaJSON(url, options) {
@@ -35,7 +37,7 @@ function fetchSchemaJSON(url, options) {
       'Content-Type': 'application/json',
       ...options.headers
     },
-    body: JSON.stringify({ query: graphql.introspectionQuery })
+    body: JSON.stringify({ query: graphql.getIntrospectionQuery() })
   })
     .then(res => res.json())
     .then(result => result.data)


### PR DESCRIPTION
Replace `graphql.introspectionQuery` with `graphql.getIntrospectionQuery()`

`introspectionQuery` constant was deprecated in favor of `getIntrospectionQuery` in [v0.12.0 of graphql](https://github.com/graphql/graphql-js/releases/tag/v0.12.0), and eventually removed in v15.

With this change I'm able to continue generating docs for a project that's just upgraded to v15 of graphql.