### PR TITLE
render subscription type at the same level as query and mutation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-markdown",
-  "version": "6.0.0",
+  "version": "6.0.0-telenia1",
   "description": "Generate documentation for your GraphQL schema in Markdown",
   "main": "src/index.js",
   "bin": "src/index.js",

--- a/src/renderSchema.js
+++ b/src/renderSchema.js
@@ -132,8 +132,16 @@ function renderSchema(schema, options) {
   const mutationType = schema.mutationType
   const mutation =
     mutationType && types.find(type => type.name === schema.mutationType.name)
+  const subscriptionType = schema.subscriptionType
+  const subscription =
+    subscriptionType &&
+    types.find(type => type.name === schema.subscriptionType.name)
   const objects = types.filter(
-    type => type.kind === 'OBJECT' && type !== query && type !== mutation
+    type =>
+      type.kind === 'OBJECT' &&
+      type !== query &&
+      type !== mutation &&
+      type !== subscription
   )
   const inputs = types.filter(type => type.kind === 'INPUT_OBJECT')
   const enums = types.filter(type => type.kind === 'ENUM')
@@ -164,6 +172,9 @@ function renderSchema(schema, options) {
     }
     if (mutation) {
       printer('  * [Mutation](#mutation)')
+    }
+    if (subscription) {
+      printer('  * [Subscription](#subscription)')
     }
     if (objects.length) {
       printer('  * [Objects](#objects)')
@@ -220,6 +231,22 @@ function renderSchema(schema, options) {
       }`
     )
     renderObject(mutation, {
+      skipTitle: true,
+      headingLevel,
+      printer,
+      getTypeURL
+    })
+  }
+
+  if (subscription) {
+    printer(
+      `\n${'#'.repeat(headingLevel + 1)} Subscription${
+        subscription.name === 'Subscription'
+          ? ''
+          : ' (' + subscription.name + ')'
+      }`
+    )
+    renderObject(subscription, {
       skipTitle: true,
       headingLevel,
       printer,


### PR DESCRIPTION
Generates the subscription type at the same level of query and mutation, and not inside objects