### PR TITLE
fix rendering of markdown in unions

### DIFF
--- a/src/renderSchema.js
+++ b/src/renderSchema.js
@@ -325,7 +325,7 @@ function renderSchema(schema, options) {
           })}</strong></td>`
         )
         if (desc) {
-          printer(`<td valign="top">${desc}</td>`)
+          printer(`<td valign="top">\n${desc}\n</td>`)
         } else {
           printer('<td></td>')
         }

--- a/test/fixtures/union-test-2.graphql
+++ b/test/fixtures/union-test-2.graphql
@@ -1,0 +1,23 @@
+type Query {
+  mammals: [Mammal]
+}
+
+"""
+*italic*
+
+* list item 1
+* list item 2
+* list item 3
+"""
+type Dog {
+  legs: Int
+}
+
+"""
+abcde
+"""
+type Seal {
+  fins: Int
+}
+
+union Mammal = Dog | Seal

--- a/test/fixtures/union-test-2.md
+++ b/test/fixtures/union-test-2.md
@@ -1,0 +1,130 @@
+# Schema Types
+
+<details>
+  <summary><strong>Table of Contents</strong></summary>
+
+  * [Query](#query)
+  * [Objects](#objects)
+    * [Dog](#dog)
+    * [Seal](#seal)
+  * [Scalars](#scalars)
+    * [Boolean](#boolean)
+    * [Int](#int)
+    * [String](#string)
+  * [Unions](#unions)
+    * [Mammal](#mammal)
+
+</details>
+
+## Query
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>mammals</strong></td>
+<td valign="top">[<a href="#mammal">Mammal</a>]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+## Objects
+
+### Dog
+
+*italic*
+
+* list item 1
+* list item 2
+* list item 3
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>legs</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Seal
+
+abcde
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>fins</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+## Scalars
+
+### Boolean
+
+The `Boolean` scalar type represents `true` or `false`.
+
+### Int
+
+The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.
+
+### String
+
+The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.
+
+
+## Unions
+
+### Mammal
+
+<table>
+<thead>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong><a href="#dog">Dog</a></strong></td>
+<td valign="top">
+*italic*
+
+* list item 1
+* list item 2
+* list item 3
+</td>
+</tr>
+<tr>
+<td valign="top"><strong><a href="#seal">Seal</a></strong></td>
+<td valign="top">
+abcde
+</td>
+</tr>
+</tbody>
+</table>

--- a/test/fixtures/union-test.graphql
+++ b/test/fixtures/union-test.graphql
@@ -8,7 +8,18 @@ type Person {
   dob: String
 }
 
-"A group of persons working together for a purpose"
+"""
+A group of **persons** <em>working</em> together for a purpose
+
+This is a more elaborate description
+
+* with some
+* items
+* to see
+* if this markdown is properly
+* translated
+
+"""
 type Organization {
   "Node ID"
   id: ID!
@@ -22,7 +33,7 @@ type Organization {
   ceo: Person
 }
 
-"Either a person or an organization"
+"Either a `Person` or an `Organization`"
 union Party = Person | Organization
 
 type Query {

--- a/test/fixtures/union-test.md
+++ b/test/fixtures/union-test.md
@@ -45,7 +45,15 @@
 
 ### Organization
 
-A group of persons working together for a purpose
+A group of **persons** <em>working</em> together for a purpose
+
+This is a more elaborate description
+
+* with some
+* items
+* to see
+* if this markdown is properly
+* translated
 
 <table>
 <thead>
@@ -175,7 +183,7 @@ The `String` scalar type represents textual data, represented as UTF-8 character
 
 ### Party
 
-Either a person or an organization
+Either a `Person` or an `Organization`
 
 <table>
 <thead>
@@ -185,11 +193,23 @@ Either a person or an organization
 <tbody>
 <tr>
 <td valign="top"><strong><a href="#person">Person</a></strong></td>
-<td valign="top">A human being</td>
+<td valign="top">
+A human being
+</td>
 </tr>
 <tr>
 <td valign="top"><strong><a href="#organization">Organization</a></strong></td>
-<td valign="top">A group of persons working together for a purpose</td>
+<td valign="top">
+A group of **persons** <em>working</em> together for a purpose
+
+This is a more elaborate description
+
+* with some
+* items
+* to see
+* if this markdown is properly
+* translated
+</td>
 </tr>
 </tbody>
 </table>

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -74,6 +74,16 @@ describe('renderSchema()', () => {
     const expected = await readFile('./fixtures/union-test.md')
     expect(printer.output).toBe(expected)
   })
+
+  it('renders markdown properly in unions', async () => {
+    const schema = await loadSchemaJSON(
+      path.resolve(__dirname, './fixtures/union-test-2.graphql')
+    )
+    const printer = createPrinter()
+    renderSchema(schema, { printer })
+    const expected = await readFile('./fixtures/union-test-2.md')
+    expect(printer.output).toBe(expected)
+  })
 })
 
 describe('diffSchema()', () => {


### PR DESCRIPTION
A tweak to add newlines around descriptions when rendering unions so the markdown is properly recognized downstream by markdown processors.

Fixes #71 

