### PR TITLE
fix for graphql 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     ]
   },
   "peerDependencies": {
-    "graphql": "^14.0.2 || ^15.0.0"
+    "graphql": "^14.0.2 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
     "deep-diff": "^1.0.2",
@@ -55,7 +55,7 @@
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
     "graphbrainz": "^8.1.0",
-    "graphql": "^14.0.2",
+    "graphql": "^16.0.0",
     "husky": "^1.1.0",
     "jest": "^23.6.0",
     "lint-staged": "^7.3.0",

--- a/src/loadSchemaJSON.js
+++ b/src/loadSchemaJSON.js
@@ -20,11 +20,10 @@ function readFile(filename) {
 function schemaToJSON(schema, options) {
   options = options || {}
   const graphql = options.graphql || DEFAULT_GRAPHQL
-  return graphql
-    .graphql(schema, graphql.getIntrospectionQuery())
-    .then(result => {
-      return result.data
-    })
+  const source = graphql.getIntrospectionQuery()
+  return graphql.graphql({ schema, source }).then(result => {
+    return result.data
+  })
 }
 
 function fetchSchemaJSON(url, options) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2137,12 +2137,10 @@ graphql@^0.13.2:
   dependencies:
     iterall "^1.2.1"
 
-graphql@^14.0.2:
-  version "14.7.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.7.0.tgz#7fa79a80a69be4a31c27dda824dc04dac2035a72"
-  integrity sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==
-  dependencies:
-    iterall "^1.2.2"
+graphql@^16.0.0:
+  version "16.6.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
+  integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
 
 "growl@~> 1.10.0":
   version "1.10.5"
@@ -2823,11 +2821,6 @@ iterall@^1.1.3, iterall@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
   integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==
-
-iterall@^1.2.2:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
-  integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
 
 jest-changed-files@^23.4.2:
   version "23.4.2"


### PR DESCRIPTION
Modify how we pass arguments to `graphql` to convert schema to json. Change from legacy positional arguments to an object (which is required in `graphql` v16+).