### PR TITLE
Add element IDs to fields for linkability, with option to also list them in TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ Options:
   --title <string>       Change the top heading title (default: 'Schema Types')
   --no-title             Do not print a default title
   --no-toc               Do not print table of contents
+  --toc-fields <list>    Expand the table of contents for the listed types
+                         (comma-separated) to link to fields within the type
+                         e.g. --toc-fields "Query,Mutation,Subscription"
   --prologue <string>    Include custom Markdown after the title
   --epilogue <string>    Include custom Markdown after everything else
   --heading-level <num>  Heading level to begin at, useful if you are embedding the
@@ -135,6 +138,8 @@ with a `__schema` property), render the schema to the console or the provided
   `console.log`.
 - **`skipTableOfContents`**: When set, rendering of "Table of contents" section
   is skipped.
+- **`tocFieldTypes`**: An array of type names whose table of contents entry will
+  be expanded to link to individual fields in a nested list.
 - **`headingLevel`**: The initial level at which to render Markdown headings in
   the output, defaults to 1. Use this if you are using `updateSchema` to embed
   the output in a larger document with other sections.

--- a/README.md
+++ b/README.md
@@ -98,8 +98,9 @@ Options:
   --no-title             Do not print a default title
   --no-toc               Do not print table of contents
   --toc-fields <list>    Expand the table of contents for the listed types
-                         (comma-separated) to link to fields within the type
-                         e.g. --toc-fields "Query,Mutation,Subscription"
+                         (comma-separated) to link to fields within those types
+                         (e.g. --toc-fields "Query,Mutation,Subscription") or use
+                         the string "*" to link to fields for all types
   --prologue <string>    Include custom Markdown after the title
   --epilogue <string>    Include custom Markdown after everything else
   --heading-level <num>  Heading level to begin at, useful if you are embedding the
@@ -139,7 +140,8 @@ with a `__schema` property), render the schema to the console or the provided
 - **`skipTableOfContents`**: When set, rendering of "Table of contents" section
   is skipped.
 - **`tocFieldTypes`**: An array of type names whose table of contents entry will
-  be expanded to link to individual fields in a nested list.
+  be expanded to link to individual fields in a nested list. Include the special
+  name `*` in the array to match all types.
 - **`headingLevel`**: The initial level at which to render Markdown headings in
   the output, defaults to 1. Use this if you are using `updateSchema` to embed
   the output in a larger document with other sections.

--- a/src/index.js
+++ b/src/index.js
@@ -33,8 +33,9 @@ function printHelp(console) {
     --no-title             Do not print a default title
     --no-toc               Do not print table of contents
     --toc-fields <list>    Expand the table of contents for the listed types
-                           (comma-separated) to link to fields within the type
-                           e.g. --toc-fields "Query,Mutation,Subscription"
+                           (comma-separated) to link to fields within those types
+                           (e.g. --toc-fields "Query,Mutation,Subscription") or use
+                           the string "*" to link to fields for all types
     --prologue <string>    Include custom Markdown after the title
     --epilogue <string>    Include custom Markdown after everything else
     --heading-level <num>  Heading level to begin at, useful if you are embedding the

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,9 @@ function printHelp(console) {
     --title <string>       Change the top heading title (default: 'Schema Types')
     --no-title             Do not print a default title
     --no-toc               Do not print table of contents
+    --toc-fields <list>    Expand the table of contents for the listed types
+                           (comma-separated) to link to fields within the type
+                           e.g. --toc-fields "Query,Mutation,Subscription"
     --prologue <string>    Include custom Markdown after the title
     --epilogue <string>    Include custom Markdown after everything else
     --heading-level <num>  Heading level to begin at, useful if you are embedding the
@@ -71,6 +74,9 @@ function run(
       obj[key] = value.join('=')
       return obj
     }, {})
+    const tocFieldTypes = args['toc-fields']
+      ? args['toc-fields'].split(',')
+      : []
     const loadOptions = { headers }
     loadSchemaJSON(schemaPath, loadOptions).then((schema) => {
       const options = {
@@ -80,6 +86,7 @@ function run(
         epilogue: args.epilogue,
         skipTableOfContents: args.toc === false,
         headingLevel: args['heading-level'],
+        tocFieldTypes,
       }
       if (options.title === false) {
         options.title = ''

--- a/src/renderSchema.js
+++ b/src/renderSchema.js
@@ -26,6 +26,7 @@ function renderObject(type, options) {
   const printer = options.printer || console.log
   const headingLevel = options.headingLevel || 1
   const getTypeURL = options.getTypeURL
+  const getFieldURL = options.getFieldURL
   const isInputObject = type.kind === 'INPUT_OBJECT'
 
   if (!skipTitle) {
@@ -51,13 +52,23 @@ function renderObject(type, options) {
 
   const fields = isInputObject ? type.inputFields : type.fields
   fields.forEach((field) => {
+    const url = getFieldURL(type, field)
+    const anchor = url && url.split('#')[1]
+    const fieldNameMarkup = anchor
+      ? `<strong id="${anchor}">${field.name}</strong>`
+      : `<strong>${field.name}</strong>`
     printer('<tr>')
     printer(
-      `<td colspan="2" valign="top"><strong>${field.name}</strong>${
+      `<td colspan="2" valign="top">${fieldNameMarkup}${
         field.isDeprecated ? ' ⚠️' : ''
       }</td>`
     )
-    printer(`<td valign="top">${renderType(field.type, { getTypeURL })}</td>`)
+    printer(
+      `<td valign="top">${renderType(field.type, {
+        getTypeURL,
+        getFieldURL,
+      })}</td>`
+    )
     if (field.description || field.isDeprecated) {
       printer('<td>')
       if (field.description) {
@@ -80,7 +91,12 @@ function renderObject(type, options) {
       field.args.forEach((arg, i) => {
         printer('<tr>')
         printer(`<td colspan="2" align="right" valign="top">${arg.name}</td>`)
-        printer(`<td valign="top">${renderType(arg.type, { getTypeURL })}</td>`)
+        printer(
+          `<td valign="top">${renderType(arg.type, {
+            getTypeURL,
+            getFieldURL,
+          })}</td>`
+        )
         if (arg.description) {
           printer('<td>')
           printer(`\n${arg.description}\n`)
@@ -106,6 +122,7 @@ function renderSchema(schema, options) {
   const printer = options.printer || console.log
   const headingLevel = options.headingLevel || 1
   const unknownTypeURL = options.unknownTypeURL
+  const tocFieldTypes = options.tocFieldTypes || []
 
   if (schema.__schema) {
     schema = schema.__schema
@@ -115,6 +132,7 @@ function renderSchema(schema, options) {
   const typeMap = schema.types.reduce((typeMap, type) => {
     return Object.assign(typeMap, { [type.name]: type })
   }, {})
+
   const getTypeURL = (type) => {
     const url = `#${type.name.toLowerCase()}`
     if (typeMap[type.name]) {
@@ -124,6 +142,11 @@ function renderSchema(schema, options) {
     } else if (unknownTypeURL) {
       return unknownTypeURL + url
     }
+  }
+
+  const getFieldURL = (type, field) => {
+    const url = getTypeURL(type)
+    return url && `${url}.${field.name.toLowerCase()}`
   }
 
   const queryType = schema.queryType
@@ -136,6 +159,7 @@ function renderSchema(schema, options) {
   const subscription =
     subscriptionType &&
     types.find((type) => type.name === schema.subscriptionType.name)
+
   const objects = types.filter(
     (type) =>
       type.kind === 'OBJECT' &&
@@ -169,23 +193,48 @@ function renderSchema(schema, options) {
     printer('  <summary><strong>Table of Contents</strong></summary>\n')
     if (query) {
       printer('  * [Query](#query)')
+      if (tocFieldTypes.includes(query.name)) {
+        query.fields.forEach((field) => {
+          printer(`    * [${field.name}](${getFieldURL(query, field)})`)
+        })
+      }
     }
     if (mutation) {
       printer('  * [Mutation](#mutation)')
+      if (tocFieldTypes.includes(mutation.name)) {
+        mutation.fields.forEach((field) => {
+          printer(`    * [${field.name}](${getFieldURL(mutation, field)})`)
+        })
+      }
     }
     if (subscription) {
       printer('  * [Subscription](#subscription)')
+      if (tocFieldTypes.includes(subscription.name)) {
+        subscription.fields.forEach((field) => {
+          printer(`    * [${field.name}](${getFieldURL(subscription, field)})`)
+        })
+      }
     }
     if (objects.length) {
       printer('  * [Objects](#objects)')
       objects.forEach((type) => {
         printer(`    * [${type.name}](#${type.name.toLowerCase()})`)
+        if (tocFieldTypes.includes(type.name)) {
+          type.fields.forEach((field) => {
+            printer(`      * [${field.name}](${getFieldURL(type, field)})`)
+          })
+        }
       })
     }
     if (inputs.length) {
       printer('  * [Inputs](#inputs)')
       inputs.forEach((type) => {
         printer(`    * [${type.name}](#${type.name.toLowerCase()})`)
+        if (tocFieldTypes.includes(type.name)) {
+          type.inputFields.forEach((field) => {
+            printer(`      * [${field.name}](${getFieldURL(type, field)})`)
+          })
+        }
       })
     }
     if (enums.length) {
@@ -204,6 +253,11 @@ function renderSchema(schema, options) {
       printer('  * [Interfaces](#interfaces)')
       interfaces.forEach((type) => {
         printer(`    * [${type.name}](#${type.name.toLowerCase()})`)
+        if (tocFieldTypes.includes(type.name)) {
+          type.inputFields.forEach((field) => {
+            printer(`      * [${field.name}](${getFieldURL(type, field)})`)
+          })
+        }
       })
     }
     if (unions.length) {
@@ -221,7 +275,13 @@ function renderSchema(schema, options) {
         query.name === 'Query' ? '' : ' (' + query.name + ')'
       }`
     )
-    renderObject(query, { skipTitle: true, headingLevel, printer, getTypeURL })
+    renderObject(query, {
+      skipTitle: true,
+      headingLevel,
+      printer,
+      getTypeURL,
+      getFieldURL,
+    })
   }
 
   if (mutation) {
@@ -235,6 +295,7 @@ function renderSchema(schema, options) {
       headingLevel,
       printer,
       getTypeURL,
+      getFieldURL,
     })
   }
 
@@ -251,20 +312,21 @@ function renderSchema(schema, options) {
       headingLevel,
       printer,
       getTypeURL,
+      getFieldURL,
     })
   }
 
   if (objects.length) {
     printer(`\n${'#'.repeat(headingLevel + 1)} Objects`)
     objects.forEach((type) =>
-      renderObject(type, { headingLevel, printer, getTypeURL })
+      renderObject(type, { headingLevel, printer, getTypeURL, getFieldURL })
     )
   }
 
   if (inputs.length) {
     printer(`\n${'#'.repeat(headingLevel + 1)} Inputs`)
     inputs.forEach((type) =>
-      renderObject(type, { headingLevel, printer, getTypeURL })
+      renderObject(type, { headingLevel, printer, getTypeURL, getFieldURL })
     )
   }
 
@@ -327,7 +389,7 @@ function renderSchema(schema, options) {
   if (interfaces.length) {
     printer(`\n${'#'.repeat(headingLevel + 1)} Interfaces\n`)
     interfaces.forEach((type) =>
-      renderObject(type, { headingLevel, printer, getTypeURL })
+      renderObject(type, { headingLevel, printer, getTypeURL, getFieldURL })
     )
   }
 
@@ -353,6 +415,7 @@ function renderSchema(schema, options) {
         printer(
           `<td valign="top"><strong>${renderType(objType, {
             getTypeURL,
+            getFieldURL,
           })}</strong></td>`
         )
         if (desc) {

--- a/src/renderSchema.js
+++ b/src/renderSchema.js
@@ -123,6 +123,7 @@ function renderSchema(schema, options) {
   const headingLevel = options.headingLevel || 1
   const unknownTypeURL = options.unknownTypeURL
   const tocFieldTypes = options.tocFieldTypes || []
+  const tocFieldAllTypes = tocFieldTypes.includes('*')
 
   if (schema.__schema) {
     schema = schema.__schema
@@ -193,7 +194,7 @@ function renderSchema(schema, options) {
     printer('  <summary><strong>Table of Contents</strong></summary>\n')
     if (query) {
       printer('  * [Query](#query)')
-      if (tocFieldTypes.includes(query.name)) {
+      if (tocFieldAllTypes || tocFieldTypes.includes(query.name)) {
         query.fields.forEach((field) => {
           printer(`    * [${field.name}](${getFieldURL(query, field)})`)
         })
@@ -201,7 +202,7 @@ function renderSchema(schema, options) {
     }
     if (mutation) {
       printer('  * [Mutation](#mutation)')
-      if (tocFieldTypes.includes(mutation.name)) {
+      if (tocFieldAllTypes || tocFieldTypes.includes(mutation.name)) {
         mutation.fields.forEach((field) => {
           printer(`    * [${field.name}](${getFieldURL(mutation, field)})`)
         })
@@ -209,7 +210,7 @@ function renderSchema(schema, options) {
     }
     if (subscription) {
       printer('  * [Subscription](#subscription)')
-      if (tocFieldTypes.includes(subscription.name)) {
+      if (tocFieldAllTypes || tocFieldTypes.includes(subscription.name)) {
         subscription.fields.forEach((field) => {
           printer(`    * [${field.name}](${getFieldURL(subscription, field)})`)
         })
@@ -219,7 +220,7 @@ function renderSchema(schema, options) {
       printer('  * [Objects](#objects)')
       objects.forEach((type) => {
         printer(`    * [${type.name}](#${type.name.toLowerCase()})`)
-        if (tocFieldTypes.includes(type.name)) {
+        if (tocFieldAllTypes || tocFieldTypes.includes(type.name)) {
           type.fields.forEach((field) => {
             printer(`      * [${field.name}](${getFieldURL(type, field)})`)
           })
@@ -230,7 +231,7 @@ function renderSchema(schema, options) {
       printer('  * [Inputs](#inputs)')
       inputs.forEach((type) => {
         printer(`    * [${type.name}](#${type.name.toLowerCase()})`)
-        if (tocFieldTypes.includes(type.name)) {
+        if (tocFieldAllTypes || tocFieldTypes.includes(type.name)) {
           type.inputFields.forEach((field) => {
             printer(`      * [${field.name}](${getFieldURL(type, field)})`)
           })
@@ -253,8 +254,8 @@ function renderSchema(schema, options) {
       printer('  * [Interfaces](#interfaces)')
       interfaces.forEach((type) => {
         printer(`    * [${type.name}](#${type.name.toLowerCase()})`)
-        if (tocFieldTypes.includes(type.name)) {
-          type.inputFields.forEach((field) => {
+        if (tocFieldAllTypes || tocFieldTypes.includes(type.name)) {
+          type.fields.forEach((field) => {
             printer(`      * [${field.name}](${getFieldURL(type, field)})`)
           })
         }

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -470,6 +470,9 @@ exports[`run() with --help arg prints the help message 1`] = `
     --title <string>       Change the top heading title (default: 'Schema Types')
     --no-title             Do not print a default title
     --no-toc               Do not print table of contents
+    --toc-fields <list>    Expand the table of contents for the listed types
+                           (comma-separated) to link to fields within the type
+                           e.g. --toc-fields "Query,Mutation,Subscription"
     --prologue <string>    Include custom Markdown after the title
     --epilogue <string>    Include custom Markdown after everything else
     --heading-level <num>  Heading level to begin at, useful if you are embedding the
@@ -506,6 +509,9 @@ exports[`run() with no args prints the help message 1`] = `
     --title <string>       Change the top heading title (default: 'Schema Types')
     --no-title             Do not print a default title
     --no-toc               Do not print table of contents
+    --toc-fields <list>    Expand the table of contents for the listed types
+                           (comma-separated) to link to fields within the type
+                           e.g. --toc-fields "Query,Mutation,Subscription"
     --prologue <string>    Include custom Markdown after the title
     --epilogue <string>    Include custom Markdown after everything else
     --heading-level <num>  Heading level to begin at, useful if you are embedding the

--- a/test/fixtures/cover-art-archive.md
+++ b/test/fixtures/cover-art-archive.md
@@ -31,7 +31,7 @@ An individual piece of album artwork from the [Cover Art Archive](https://musicb
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>fileID</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiveimage.fileid">fileID</strong></td>
 <td valign="top">String!</td>
 <td>
 
@@ -40,7 +40,7 @@ The Internet Archive’s internal file ID for the image.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>image</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiveimage.image">image</strong></td>
 <td valign="top">URLString!</td>
 <td>
 
@@ -49,7 +49,7 @@ The URL at which the image can be found.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>thumbnails</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiveimage.thumbnails">thumbnails</strong></td>
 <td valign="top"><a href="#coverartarchiveimagethumbnails">CoverArtArchiveImageThumbnails</a>!</td>
 <td>
 
@@ -58,7 +58,7 @@ A set of thumbnails for the image.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>front</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiveimage.front">front</strong></td>
 <td valign="top">Boolean!</td>
 <td>
 
@@ -67,7 +67,7 @@ Whether this image depicts the “main front” of the release.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>back</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiveimage.back">back</strong></td>
 <td valign="top">Boolean!</td>
 <td>
 
@@ -76,7 +76,7 @@ Whether this image depicts the “main back” of the release.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>types</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiveimage.types">types</strong></td>
 <td valign="top">[String]!</td>
 <td>
 
@@ -86,7 +86,7 @@ describing what part(s) of the release the image includes.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edit</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiveimage.edit">edit</strong></td>
 <td valign="top">Int</td>
 <td>
 
@@ -95,7 +95,7 @@ The MusicBrainz edit ID.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>approved</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiveimage.approved">approved</strong></td>
 <td valign="top">Boolean</td>
 <td>
 
@@ -104,7 +104,7 @@ Whether the image was approved by the MusicBrainz edit system.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>comment</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiveimage.comment">comment</strong></td>
 <td valign="top">String</td>
 <td>
 
@@ -130,7 +130,7 @@ URLs for thumbnails of different sizes for a particular piece of cover art.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>small</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiveimagethumbnails.small">small</strong></td>
 <td valign="top">URLString</td>
 <td>
 
@@ -140,7 +140,7 @@ The URL of a small version of the cover art, where the maximum dimension is
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>large</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiveimagethumbnails.large">large</strong></td>
 <td valign="top">URLString</td>
 <td>
 
@@ -169,7 +169,7 @@ as well as a summary of what artwork is available.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>front</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiverelease.front">front</strong></td>
 <td valign="top">URLString</td>
 <td>
 
@@ -196,7 +196,7 @@ retrieved as well.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>back</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiverelease.back">back</strong></td>
 <td valign="top">URLString</td>
 <td>
 
@@ -222,7 +222,7 @@ retrieved as well.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>images</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiverelease.images">images</strong></td>
 <td valign="top">[<a href="#coverartarchiveimage">CoverArtArchiveImage</a>]!</td>
 <td>
 
@@ -232,7 +232,7 @@ media and packaging.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artwork</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiverelease.artwork">artwork</strong></td>
 <td valign="top">Boolean!</td>
 <td>
 
@@ -241,7 +241,7 @@ Whether there is artwork present for this release.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>count</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiverelease.count">count</strong></td>
 <td valign="top">Int!</td>
 <td>
 
@@ -250,7 +250,7 @@ The number of artwork images present for this release.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>release</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiverelease.release">release</strong></td>
 <td valign="top"><a href="#release">Release</a></td>
 <td>
 
@@ -280,7 +280,7 @@ MusicBrainz as one release.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>coverArtArchive</strong></td>
+<td colspan="2" valign="top"><strong id="release.coverartarchive">coverArtArchive</strong></td>
 <td valign="top"><a href="#coverartarchiverelease">CoverArtArchiveRelease</a></td>
 <td>
 
@@ -315,7 +315,7 @@ album – it doesn’t matter how many CDs or editions/versions it had.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>coverArtArchive</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.coverartarchive">coverArtArchive</strong></td>
 <td valign="top"><a href="#coverartarchiverelease">CoverArtArchiveRelease</a></td>
 <td>
 

--- a/test/fixtures/graphbrainz-updateSchema-initial.md
+++ b/test/fixtures/graphbrainz-updateSchema-initial.md
@@ -107,7 +107,7 @@ requests can be made.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>lookup</strong></td>
+<td colspan="2" valign="top"><strong id="query.lookup">lookup</strong></td>
 <td valign="top"><a href="#lookupquery">LookupQuery</a></td>
 <td>
 
@@ -116,7 +116,7 @@ Perform a lookup of a MusicBrainz entity by its MBID.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>browse</strong></td>
+<td colspan="2" valign="top"><strong id="query.browse">browse</strong></td>
 <td valign="top"><a href="#browsequery">BrowseQuery</a></td>
 <td>
 
@@ -125,7 +125,7 @@ Browse all MusicBrainz entities directly linked to another entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>search</strong></td>
+<td colspan="2" valign="top"><strong id="query.search">search</strong></td>
 <td valign="top"><a href="#searchquery">SearchQuery</a></td>
 <td>
 
@@ -134,7 +134,7 @@ Search for MusicBrainz entities using Lucene query syntax.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="query.node">node</strong></td>
 <td valign="top"><a href="#node">Node</a></td>
 <td>
 
@@ -173,7 +173,7 @@ entity will be given as a result – even if the actual name wouldn’t be.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="alias.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -182,7 +182,7 @@ The aliased name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>sortName</strong></td>
+<td colspan="2" valign="top"><strong id="alias.sortname">sortName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -193,7 +193,7 @@ the front).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>locale</strong></td>
+<td colspan="2" valign="top"><strong id="alias.locale">locale</strong></td>
 <td valign="top"><a href="#locale">Locale</a></td>
 <td>
 
@@ -203,7 +203,7 @@ used.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>primary</strong></td>
+<td colspan="2" valign="top"><strong id="alias.primary">primary</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
 
@@ -213,7 +213,7 @@ specified locale (this could mean the most recent or the most common).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="alias.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -223,7 +223,7 @@ search hint, etc.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="alias.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -251,7 +251,7 @@ or settlements (countries, cities, or the like).
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="area.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -260,7 +260,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="area.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -269,7 +269,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="area.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -278,7 +278,7 @@ The official name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>sortName</strong></td>
+<td colspan="2" valign="top"><strong id="area.sortname">sortName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -289,7 +289,7 @@ the front).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="area.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -298,7 +298,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="area.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -308,7 +308,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>isoCodes</strong></td>
+<td colspan="2" valign="top"><strong id="area.isocodes">isoCodes</strong></td>
 <td valign="top">[<a href="#string">String</a>]</td>
 <td>
 
@@ -328,7 +328,7 @@ Available ISO standards are 3166-1, 3166-2, and 3166-3.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="area.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -338,7 +338,7 @@ values](https://musicbrainz.org/doc/Area)).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="area.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -348,7 +348,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="area.artists">artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
 
@@ -367,7 +367,7 @@ A list of artists linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>events</strong></td>
+<td colspan="2" valign="top"><strong id="area.events">events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
 
@@ -386,7 +386,7 @@ A list of events linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>labels</strong></td>
+<td colspan="2" valign="top"><strong id="area.labels">labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
 
@@ -405,7 +405,7 @@ A list of labels linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>places</strong></td>
+<td colspan="2" valign="top"><strong id="area.places">places</strong></td>
 <td valign="top"><a href="#placeconnection">PlaceConnection</a></td>
 <td>
 
@@ -424,7 +424,7 @@ A list of places linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="area.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -461,7 +461,7 @@ Filter by one or more release statuses.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="area.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -470,7 +470,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="area.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -489,7 +489,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="area.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -525,7 +525,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="areaconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -534,7 +534,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="areaconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#areaedge">AreaEdge</a>]</td>
 <td>
 
@@ -543,7 +543,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="areaconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#area">Area</a>]</td>
 <td>
 
@@ -553,7 +553,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="areaconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -580,7 +580,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="areaedge.node">node</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
 
@@ -589,7 +589,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="areaedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -598,7 +598,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="areaedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -629,7 +629,7 @@ even a fictional character.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="artist.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -638,7 +638,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="artist.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -647,7 +647,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="artist.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -656,7 +656,7 @@ The official name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>sortName</strong></td>
+<td colspan="2" valign="top"><strong id="artist.sortname">sortName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -667,7 +667,7 @@ the front).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="artist.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -676,7 +676,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="artist.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -686,7 +686,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>country</strong></td>
+<td colspan="2" valign="top"><strong id="artist.country">country</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -696,7 +696,7 @@ is often, but not always, its birth/formation country.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>area</strong></td>
+<td colspan="2" valign="top"><strong id="artist.area">area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
 
@@ -706,7 +706,7 @@ is often, but not always, its birth/formation country.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>beginArea</strong></td>
+<td colspan="2" valign="top"><strong id="artist.beginarea">beginArea</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
 
@@ -716,7 +716,7 @@ they were born, if the artist is a person).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>endArea</strong></td>
+<td colspan="2" valign="top"><strong id="artist.endarea">endArea</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
 
@@ -726,7 +726,7 @@ they died, if the artist is a person).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>lifeSpan</strong></td>
+<td colspan="2" valign="top"><strong id="artist.lifespan">lifeSpan</strong></td>
 <td valign="top"><a href="#lifespan">LifeSpan</a></td>
 <td>
 
@@ -736,7 +736,7 @@ meaning depends on the type of entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>gender</strong></td>
+<td colspan="2" valign="top"><strong id="artist.gender">gender</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -746,7 +746,7 @@ neither. Groups do not have genders.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>genderID</strong></td>
+<td colspan="2" valign="top"><strong id="artist.genderid">genderID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -756,7 +756,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="artist.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -765,7 +765,7 @@ Whether an artist is a person, a group, or something else.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="artist.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -775,7 +775,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>ipis</strong></td>
+<td colspan="2" valign="top"><strong id="artist.ipis">ipis</strong></td>
 <td valign="top">[<a href="#ipi">IPI</a>]</td>
 <td>
 
@@ -785,7 +785,7 @@ List of [Interested Parties Information](https://musicbrainz.org/doc/IPI)
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>isnis</strong></td>
+<td colspan="2" valign="top"><strong id="artist.isnis">isnis</strong></td>
 <td valign="top">[<a href="#isni">ISNI</a>]</td>
 <td>
 
@@ -795,7 +795,7 @@ List of [International Standard Name Identifier](https://musicbrainz.org/doc/ISN
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>recordings</strong></td>
+<td colspan="2" valign="top"><strong id="artist.recordings">recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
 
@@ -814,7 +814,7 @@ A list of recordings linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="artist.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -851,7 +851,7 @@ Filter by one or more release statuses.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releaseGroups</strong></td>
+<td colspan="2" valign="top"><strong id="artist.releasegroups">releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
 
@@ -879,7 +879,7 @@ Filter by one or more release group types.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>works</strong></td>
+<td colspan="2" valign="top"><strong id="artist.works">works</strong></td>
 <td valign="top"><a href="#workconnection">WorkConnection</a></td>
 <td>
 
@@ -898,7 +898,7 @@ A list of works linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="artist.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -907,7 +907,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="artist.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -926,7 +926,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>rating</strong></td>
+<td colspan="2" valign="top"><strong id="artist.rating">rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
 
@@ -935,7 +935,7 @@ The rating users have given to this entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="artist.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -971,7 +971,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="artistconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -980,7 +980,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="artistconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#artistedge">ArtistEdge</a>]</td>
 <td>
 
@@ -989,7 +989,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="artistconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#artist">Artist</a>]</td>
 <td>
 
@@ -999,7 +999,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="artistconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -1030,7 +1030,7 @@ track, etc., and join phrases between them.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>artist</strong></td>
+<td colspan="2" valign="top"><strong id="artistcredit.artist">artist</strong></td>
 <td valign="top"><a href="#artist">Artist</a></td>
 <td>
 
@@ -1040,7 +1040,7 @@ credits.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="artistcredit.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -1050,7 +1050,7 @@ track, etc.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>joinPhrase</strong></td>
+<td colspan="2" valign="top"><strong id="artistcredit.joinphrase">joinPhrase</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -1077,7 +1077,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="artistedge.node">node</strong></td>
 <td valign="top"><a href="#artist">Artist</a></td>
 <td>
 
@@ -1086,7 +1086,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="artistedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -1095,7 +1095,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="artistedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -1123,7 +1123,7 @@ entity.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>areas</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.areas">areas</strong></td>
 <td valign="top"><a href="#areaconnection">AreaConnection</a></td>
 <td>
 
@@ -1151,7 +1151,7 @@ The MBID of a collection in which the entity is found.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.artists">artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
 
@@ -1224,7 +1224,7 @@ The MBID of a work to which the entity is linked.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -1333,7 +1333,7 @@ The MBID of a work to which the entity is linked.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>events</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.events">events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
 
@@ -1388,7 +1388,7 @@ The MBID of a place to which the entity is linked.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>labels</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.labels">labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
 
@@ -1434,7 +1434,7 @@ The MBID of a release to which the entity is linked.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>places</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.places">places</strong></td>
 <td valign="top"><a href="#placeconnection">PlaceConnection</a></td>
 <td>
 
@@ -1471,7 +1471,7 @@ The MBID of a collection in which the entity is found.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>recordings</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.recordings">recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
 
@@ -1527,7 +1527,7 @@ The MBID of a release to which the entity is linked.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -1647,7 +1647,7 @@ Filter by one or more release statuses.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releaseGroups</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.releasegroups">releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
 
@@ -1702,7 +1702,7 @@ Filter by one or more release group types.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>works</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.works">works</strong></td>
 <td valign="top"><a href="#workconnection">WorkConnection</a></td>
 <td>
 
@@ -1767,7 +1767,7 @@ lists of entities that users can create.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="collection.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -1776,7 +1776,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="collection.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -1785,7 +1785,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="collection.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -1794,7 +1794,7 @@ The official name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>editor</strong></td>
+<td colspan="2" valign="top"><strong id="collection.editor">editor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -1803,7 +1803,7 @@ The username of the editor who created the collection.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>entityType</strong></td>
+<td colspan="2" valign="top"><strong id="collection.entitytype">entityType</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -1812,7 +1812,7 @@ The type of entity listed in the collection.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="collection.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -1821,7 +1821,7 @@ The type of collection.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="collection.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -1831,7 +1831,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>areas</strong></td>
+<td colspan="2" valign="top"><strong id="collection.areas">areas</strong></td>
 <td valign="top"><a href="#areaconnection">AreaConnection</a></td>
 <td>
 
@@ -1850,7 +1850,7 @@ The list of areas found in this collection.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="collection.artists">artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
 
@@ -1869,7 +1869,7 @@ The list of artists found in this collection.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>events</strong></td>
+<td colspan="2" valign="top"><strong id="collection.events">events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
 
@@ -1888,7 +1888,7 @@ The list of events found in this collection.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>instruments</strong></td>
+<td colspan="2" valign="top"><strong id="collection.instruments">instruments</strong></td>
 <td valign="top"><a href="#instrumentconnection">InstrumentConnection</a></td>
 <td>
 
@@ -1907,7 +1907,7 @@ The list of instruments found in this collection.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>labels</strong></td>
+<td colspan="2" valign="top"><strong id="collection.labels">labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
 
@@ -1926,7 +1926,7 @@ The list of labels found in this collection.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>places</strong></td>
+<td colspan="2" valign="top"><strong id="collection.places">places</strong></td>
 <td valign="top"><a href="#placeconnection">PlaceConnection</a></td>
 <td>
 
@@ -1945,7 +1945,7 @@ The list of places found in this collection.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>recordings</strong></td>
+<td colspan="2" valign="top"><strong id="collection.recordings">recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
 
@@ -1964,7 +1964,7 @@ The list of recordings found in this collection.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="collection.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -2001,7 +2001,7 @@ Filter by one or more release statuses.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releaseGroups</strong></td>
+<td colspan="2" valign="top"><strong id="collection.releasegroups">releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
 
@@ -2029,7 +2029,7 @@ Filter by one or more release group types.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>series</strong></td>
+<td colspan="2" valign="top"><strong id="collection.series">series</strong></td>
 <td valign="top"><a href="#seriesconnection">SeriesConnection</a></td>
 <td>
 
@@ -2048,7 +2048,7 @@ The list of series found in this collection.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>works</strong></td>
+<td colspan="2" valign="top"><strong id="collection.works">works</strong></td>
 <td valign="top"><a href="#workconnection">WorkConnection</a></td>
 <td>
 
@@ -2084,7 +2084,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="collectionconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -2093,7 +2093,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="collectionconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#collectionedge">CollectionEdge</a>]</td>
 <td>
 
@@ -2102,7 +2102,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="collectionconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#collection">Collection</a>]</td>
 <td>
 
@@ -2112,7 +2112,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="collectionconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -2139,7 +2139,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="collectionedge.node">node</strong></td>
 <td valign="top"><a href="#collection">Collection</a></td>
 <td>
 
@@ -2148,7 +2148,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="collectionedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -2157,7 +2157,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="collectionedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -2184,7 +2184,7 @@ Geographic coordinates described with latitude and longitude.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>latitude</strong></td>
+<td colspan="2" valign="top"><strong id="coordinates.latitude">latitude</strong></td>
 <td valign="top"><a href="#degrees">Degrees</a></td>
 <td>
 
@@ -2193,7 +2193,7 @@ The north–south position of a point on the Earth’s surface.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>longitude</strong></td>
+<td colspan="2" valign="top"><strong id="coordinates.longitude">longitude</strong></td>
 <td valign="top"><a href="#degrees">Degrees</a></td>
 <td>
 
@@ -2220,7 +2220,7 @@ particular [disc ID](https://musicbrainz.org/doc/Disc_ID).
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="disc.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -2229,7 +2229,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>discID</strong></td>
+<td colspan="2" valign="top"><strong id="disc.discid">discID</strong></td>
 <td valign="top"><a href="#discid">DiscID</a>!</td>
 <td>
 
@@ -2238,7 +2238,7 @@ The [disc ID](https://musicbrainz.org/doc/Disc_ID) of this disc.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>offsetCount</strong></td>
+<td colspan="2" valign="top"><strong id="disc.offsetcount">offsetCount</strong></td>
 <td valign="top"><a href="#int">Int</a>!</td>
 <td>
 
@@ -2247,7 +2247,7 @@ The number of offsets (tracks) on the disc.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>offsets</strong></td>
+<td colspan="2" valign="top"><strong id="disc.offsets">offsets</strong></td>
 <td valign="top">[<a href="#int">Int</a>]</td>
 <td>
 
@@ -2256,7 +2256,7 @@ The sector offset of each track on the disc.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>sectors</strong></td>
+<td colspan="2" valign="top"><strong id="disc.sectors">sectors</strong></td>
 <td valign="top"><a href="#int">Int</a>!</td>
 <td>
 
@@ -2265,7 +2265,7 @@ The sector offset of the lead-out (the end of the disc).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="disc.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -2303,7 +2303,7 @@ Generally this means live performances, like concerts and festivals.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="event.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -2312,7 +2312,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="event.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -2321,7 +2321,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="event.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2330,7 +2330,7 @@ The official name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="event.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2339,7 +2339,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="event.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -2349,7 +2349,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>lifeSpan</strong></td>
+<td colspan="2" valign="top"><strong id="event.lifespan">lifeSpan</strong></td>
 <td valign="top"><a href="#lifespan">LifeSpan</a></td>
 <td>
 
@@ -2359,7 +2359,7 @@ meaning depends on the type of entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>time</strong></td>
+<td colspan="2" valign="top"><strong id="event.time">time</strong></td>
 <td valign="top"><a href="#time">Time</a></td>
 <td>
 
@@ -2368,7 +2368,7 @@ The start time of the event.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cancelled</strong></td>
+<td colspan="2" valign="top"><strong id="event.cancelled">cancelled</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
 
@@ -2377,7 +2377,7 @@ Whether or not the event took place.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>setlist</strong></td>
+<td colspan="2" valign="top"><strong id="event.setlist">setlist</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2388,7 +2388,7 @@ for syntax and examples.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="event.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2397,7 +2397,7 @@ What kind of event the event is, e.g. concert, festival, etc.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="event.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -2407,7 +2407,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="event.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -2416,7 +2416,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="event.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -2435,7 +2435,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>rating</strong></td>
+<td colspan="2" valign="top"><strong id="event.rating">rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
 
@@ -2444,7 +2444,7 @@ The rating users have given to this entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="event.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -2480,7 +2480,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="eventconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -2489,7 +2489,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="eventconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#eventedge">EventEdge</a>]</td>
 <td>
 
@@ -2498,7 +2498,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="eventconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#event">Event</a>]</td>
 <td>
 
@@ -2508,7 +2508,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="eventconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -2535,7 +2535,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="eventedge.node">node</strong></td>
 <td valign="top"><a href="#event">Event</a></td>
 <td>
 
@@ -2544,7 +2544,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="eventedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -2553,7 +2553,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="eventedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -2582,7 +2582,7 @@ used in relationships between two other entities.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -2591,7 +2591,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -2600,7 +2600,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2609,7 +2609,7 @@ The official name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2618,7 +2618,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -2628,7 +2628,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>description</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.description">description</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2638,7 +2638,7 @@ instrument.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2649,7 +2649,7 @@ classification.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -2659,7 +2659,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -2668,7 +2668,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -2687,7 +2687,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -2723,7 +2723,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="instrumentconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -2732,7 +2732,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="instrumentconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#instrumentedge">InstrumentEdge</a>]</td>
 <td>
 
@@ -2741,7 +2741,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="instrumentconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#instrument">Instrument</a>]</td>
 <td>
 
@@ -2751,7 +2751,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="instrumentconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -2778,7 +2778,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="instrumentedge.node">node</strong></td>
 <td valign="top"><a href="#instrument">Instrument</a></td>
 <td>
 
@@ -2787,7 +2787,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="instrumentedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -2796,7 +2796,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="instrumentedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -2825,7 +2825,7 @@ represent a record company.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="label.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -2834,7 +2834,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="label.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -2843,7 +2843,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="label.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2852,7 +2852,7 @@ The official name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>sortName</strong></td>
+<td colspan="2" valign="top"><strong id="label.sortname">sortName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2863,7 +2863,7 @@ the front).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="label.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2872,7 +2872,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="label.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -2882,7 +2882,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>country</strong></td>
+<td colspan="2" valign="top"><strong id="label.country">country</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2891,7 +2891,7 @@ The country of origin for the label.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>area</strong></td>
+<td colspan="2" valign="top"><strong id="label.area">area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
 
@@ -2900,7 +2900,7 @@ The area in which the label is based.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>lifeSpan</strong></td>
+<td colspan="2" valign="top"><strong id="label.lifespan">lifeSpan</strong></td>
 <td valign="top"><a href="#lifespan">LifeSpan</a></td>
 <td>
 
@@ -2910,7 +2910,7 @@ meaning depends on the type of entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>labelCode</strong></td>
+<td colspan="2" valign="top"><strong id="label.labelcode">labelCode</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -2920,7 +2920,7 @@ of the label.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>ipis</strong></td>
+<td colspan="2" valign="top"><strong id="label.ipis">ipis</strong></td>
 <td valign="top">[<a href="#ipi">IPI</a>]</td>
 <td>
 
@@ -2930,7 +2930,7 @@ codes for the label.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="label.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2940,7 +2940,7 @@ imprint, production, distributor, rights society, etc.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="label.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -2950,7 +2950,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="label.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -2987,7 +2987,7 @@ Filter by one or more release statuses.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="label.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -2996,7 +2996,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="label.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -3015,7 +3015,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>rating</strong></td>
+<td colspan="2" valign="top"><strong id="label.rating">rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
 
@@ -3024,7 +3024,7 @@ The rating users have given to this entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="label.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -3060,7 +3060,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="labelconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -3069,7 +3069,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="labelconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#labeledge">LabelEdge</a>]</td>
 <td>
 
@@ -3078,7 +3078,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="labelconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#label">Label</a>]</td>
 <td>
 
@@ -3088,7 +3088,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="labelconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -3115,7 +3115,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="labeledge.node">node</strong></td>
 <td valign="top"><a href="#label">Label</a></td>
 <td>
 
@@ -3124,7 +3124,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="labeledge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -3133,7 +3133,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="labeledge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -3161,7 +3161,7 @@ lifetime, including whether it has ended (even if the date is unknown).
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>begin</strong></td>
+<td colspan="2" valign="top"><strong id="lifespan.begin">begin</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
 
@@ -3170,7 +3170,7 @@ The start date of the entity’s life span.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>end</strong></td>
+<td colspan="2" valign="top"><strong id="lifespan.end">end</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
 
@@ -3179,7 +3179,7 @@ The end date of the entity’s life span.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>ended</strong></td>
+<td colspan="2" valign="top"><strong id="lifespan.ended">ended</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
 
@@ -3205,7 +3205,7 @@ A lookup of an individual MusicBrainz entity by its MBID.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>area</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.area">area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
 
@@ -3223,7 +3223,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artist</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.artist">artist</strong></td>
 <td valign="top"><a href="#artist">Artist</a></td>
 <td>
 
@@ -3241,7 +3241,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collection</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.collection">collection</strong></td>
 <td valign="top"><a href="#collection">Collection</a></td>
 <td>
 
@@ -3259,7 +3259,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disc</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.disc">disc</strong></td>
 <td valign="top"><a href="#disc">Disc</a></td>
 <td>
 
@@ -3278,7 +3278,7 @@ of the disc.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>event</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.event">event</strong></td>
 <td valign="top"><a href="#event">Event</a></td>
 <td>
 
@@ -3296,7 +3296,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>instrument</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.instrument">instrument</strong></td>
 <td valign="top"><a href="#instrument">Instrument</a></td>
 <td>
 
@@ -3314,7 +3314,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>label</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.label">label</strong></td>
 <td valign="top"><a href="#label">Label</a></td>
 <td>
 
@@ -3332,7 +3332,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>place</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.place">place</strong></td>
 <td valign="top"><a href="#place">Place</a></td>
 <td>
 
@@ -3350,7 +3350,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>recording</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.recording">recording</strong></td>
 <td valign="top"><a href="#recording">Recording</a></td>
 <td>
 
@@ -3368,7 +3368,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>release</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.release">release</strong></td>
 <td valign="top"><a href="#release">Release</a></td>
 <td>
 
@@ -3386,7 +3386,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releaseGroup</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.releasegroup">releaseGroup</strong></td>
 <td valign="top"><a href="#releasegroup">ReleaseGroup</a></td>
 <td>
 
@@ -3404,7 +3404,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>series</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.series">series</strong></td>
 <td valign="top"><a href="#series">Series</a></td>
 <td>
 
@@ -3422,7 +3422,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>url</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.url">url</strong></td>
 <td valign="top"><a href="#url">URL</a></td>
 <td>
 
@@ -3449,7 +3449,7 @@ The web address of the URL entity to look up.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>work</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.work">work</strong></td>
 <td valign="top"><a href="#work">Work</a></td>
 <td>
 
@@ -3488,7 +3488,7 @@ cassette) and can optionally also have a title.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>title</strong></td>
+<td colspan="2" valign="top"><strong id="medium.title">title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3497,7 +3497,7 @@ The title of this particular medium.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>format</strong></td>
+<td colspan="2" valign="top"><strong id="medium.format">format</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3507,7 +3507,7 @@ the medium (e.g. CD, DVD, vinyl, cassette).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>formatID</strong></td>
+<td colspan="2" valign="top"><strong id="medium.formatid">formatID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -3517,7 +3517,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>position</strong></td>
+<td colspan="2" valign="top"><strong id="medium.position">position</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -3527,7 +3527,7 @@ multi-disc release).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>trackCount</strong></td>
+<td colspan="2" valign="top"><strong id="medium.trackcount">trackCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -3536,7 +3536,7 @@ The number of audio tracks on this medium.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>discs</strong></td>
+<td colspan="2" valign="top"><strong id="medium.discs">discs</strong></td>
 <td valign="top">[<a href="#disc">Disc</a>]</td>
 <td>
 
@@ -3545,7 +3545,7 @@ A list of physical discs and their disc IDs for this medium.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tracks</strong></td>
+<td colspan="2" valign="top"><strong id="medium.tracks">tracks</strong></td>
 <td valign="top">[<a href="#track">Track</a>]</td>
 <td>
 
@@ -3571,7 +3571,7 @@ Information about pagination in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>hasNextPage</strong></td>
+<td colspan="2" valign="top"><strong id="pageinfo.hasnextpage">hasNextPage</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a>!</td>
 <td>
 
@@ -3580,7 +3580,7 @@ When paginating forwards, are there more items?
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>hasPreviousPage</strong></td>
+<td colspan="2" valign="top"><strong id="pageinfo.haspreviouspage">hasPreviousPage</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a>!</td>
 <td>
 
@@ -3589,7 +3589,7 @@ When paginating backwards, are there more items?
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>startCursor</strong></td>
+<td colspan="2" valign="top"><strong id="pageinfo.startcursor">startCursor</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3598,7 +3598,7 @@ When paginating backwards, the cursor to continue.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>endCursor</strong></td>
+<td colspan="2" valign="top"><strong id="pageinfo.endcursor">endCursor</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3625,7 +3625,7 @@ or other place where music is performed, recorded, engineered, etc.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="place.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -3634,7 +3634,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="place.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -3643,7 +3643,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="place.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3652,7 +3652,7 @@ The official name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="place.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3661,7 +3661,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="place.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -3671,7 +3671,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>address</strong></td>
+<td colspan="2" valign="top"><strong id="place.address">address</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3681,7 +3681,7 @@ standard addressing format for the country it is located in.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>area</strong></td>
+<td colspan="2" valign="top"><strong id="place.area">area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
 
@@ -3691,7 +3691,7 @@ which the place is located.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>coordinates</strong></td>
+<td colspan="2" valign="top"><strong id="place.coordinates">coordinates</strong></td>
 <td valign="top"><a href="#coordinates">Coordinates</a></td>
 <td>
 
@@ -3700,7 +3700,7 @@ The geographic coordinates of the place.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>lifeSpan</strong></td>
+<td colspan="2" valign="top"><strong id="place.lifespan">lifeSpan</strong></td>
 <td valign="top"><a href="#lifespan">LifeSpan</a></td>
 <td>
 
@@ -3710,7 +3710,7 @@ meaning depends on the type of entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="place.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3720,7 +3720,7 @@ function.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="place.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -3730,7 +3730,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>events</strong></td>
+<td colspan="2" valign="top"><strong id="place.events">events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
 
@@ -3749,7 +3749,7 @@ A list of events linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="place.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -3758,7 +3758,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="place.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -3777,7 +3777,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="place.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -3813,7 +3813,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="placeconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -3822,7 +3822,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="placeconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#placeedge">PlaceEdge</a>]</td>
 <td>
 
@@ -3831,7 +3831,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="placeconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#place">Place</a>]</td>
 <td>
 
@@ -3841,7 +3841,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="placeconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -3868,7 +3868,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="placeedge.node">node</strong></td>
 <td valign="top"><a href="#place">Place</a></td>
 <td>
 
@@ -3877,7 +3877,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="placeedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -3886,7 +3886,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="placeedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -3916,7 +3916,7 @@ for the entity.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>voteCount</strong></td>
+<td colspan="2" valign="top"><strong id="rating.votecount">voteCount</strong></td>
 <td valign="top"><a href="#int">Int</a>!</td>
 <td>
 
@@ -3925,7 +3925,7 @@ The number of votes that have contributed to the rating.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>value</strong></td>
+<td colspan="2" valign="top"><strong id="rating.value">value</strong></td>
 <td valign="top"><a href="#float">Float</a></td>
 <td>
 
@@ -3962,7 +3962,7 @@ or mixing.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="recording.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -3971,7 +3971,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="recording.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -3980,7 +3980,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>title</strong></td>
+<td colspan="2" valign="top"><strong id="recording.title">title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3989,7 +3989,7 @@ The official title of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="recording.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3998,7 +3998,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="recording.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -4008,7 +4008,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artistCredit</strong> ⚠️</td>
+<td colspan="2" valign="top"><strong id="recording.artistcredit">artistCredit</strong> ⚠️</td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
 
@@ -4027,7 +4027,7 @@ and will be removed in a major release in the future. Use the equivalent
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artistCredits</strong></td>
+<td colspan="2" valign="top"><strong id="recording.artistcredits">artistCredits</strong></td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
 
@@ -4036,7 +4036,7 @@ The main credited artist(s).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>isrcs</strong></td>
+<td colspan="2" valign="top"><strong id="recording.isrcs">isrcs</strong></td>
 <td valign="top">[<a href="#isrc">ISRC</a>]</td>
 <td>
 
@@ -4046,7 +4046,7 @@ A list of [International Standard Recording Codes](https://musicbrainz.org/doc/I
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>length</strong></td>
+<td colspan="2" valign="top"><strong id="recording.length">length</strong></td>
 <td valign="top"><a href="#duration">Duration</a></td>
 <td>
 
@@ -4056,7 +4056,7 @@ from the lengths of the tracks using it.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>video</strong></td>
+<td colspan="2" valign="top"><strong id="recording.video">video</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
 
@@ -4065,7 +4065,7 @@ Whether this is a video recording.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="recording.artists">artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
 
@@ -4084,7 +4084,7 @@ A list of artists linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="recording.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -4121,7 +4121,7 @@ Filter by one or more release statuses.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="recording.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -4130,7 +4130,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="recording.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -4149,7 +4149,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>rating</strong></td>
+<td colspan="2" valign="top"><strong id="recording.rating">rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
 
@@ -4158,7 +4158,7 @@ The rating users have given to this entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="recording.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -4194,7 +4194,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="recordingconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -4203,7 +4203,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="recordingconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#recordingedge">RecordingEdge</a>]</td>
 <td>
 
@@ -4212,7 +4212,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="recordingconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#recording">Recording</a>]</td>
 <td>
 
@@ -4222,7 +4222,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="recordingconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -4249,7 +4249,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="recordingedge.node">node</strong></td>
 <td valign="top"><a href="#recording">Recording</a></td>
 <td>
 
@@ -4258,7 +4258,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="recordingedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -4267,7 +4267,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="recordingedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -4296,7 +4296,7 @@ other and to URLs outside MusicBrainz.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>target</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.target">target</strong></td>
 <td valign="top"><a href="#entity">Entity</a>!</td>
 <td>
 
@@ -4305,7 +4305,7 @@ The target entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>direction</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.direction">direction</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -4314,7 +4314,7 @@ The direction of the relationship.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>targetType</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.targettype">targetType</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -4323,7 +4323,7 @@ The type of entity on the receiving end of the relationship.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>sourceCredit</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.sourcecredit">sourceCredit</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -4333,7 +4333,7 @@ from its main (performance) name.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>targetCredit</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.targetcredit">targetCredit</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -4343,7 +4343,7 @@ from its main (performance) name.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>begin</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.begin">begin</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
 
@@ -4352,7 +4352,7 @@ The date on which the relationship became applicable.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>end</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.end">end</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
 
@@ -4361,7 +4361,7 @@ The date on which the relationship became no longer applicable.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>ended</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.ended">ended</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
 
@@ -4370,7 +4370,7 @@ Whether the relationship still applies.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>attributes</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.attributes">attributes</strong></td>
 <td valign="top">[<a href="#string">String</a>]</td>
 <td>
 
@@ -4382,7 +4382,7 @@ relationship type.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -4391,7 +4391,7 @@ The type of relationship.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -4418,7 +4418,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="relationshipconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -4427,7 +4427,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="relationshipconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#relationshipedge">RelationshipEdge</a>]</td>
 <td>
 
@@ -4436,7 +4436,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="relationshipconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#relationship">Relationship</a>]</td>
 <td>
 
@@ -4446,7 +4446,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="relationshipconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -4473,7 +4473,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="relationshipedge.node">node</strong></td>
 <td valign="top"><a href="#relationship">Relationship</a></td>
 <td>
 
@@ -4482,7 +4482,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="relationshipedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -4491,7 +4491,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="relationshipedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -4518,7 +4518,7 @@ Lists of entity relationships for each entity type.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>areas</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.areas">areas</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -4575,7 +4575,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.artists">artists</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -4632,7 +4632,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>events</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.events">events</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -4689,7 +4689,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>instruments</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.instruments">instruments</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -4746,7 +4746,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>labels</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.labels">labels</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -4803,7 +4803,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>places</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.places">places</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -4860,7 +4860,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>recordings</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.recordings">recordings</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -4917,7 +4917,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.releases">releases</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -4974,7 +4974,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releaseGroups</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.releasegroups">releaseGroups</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -5031,7 +5031,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>series</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.series">series</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -5088,7 +5088,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>urls</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.urls">urls</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -5145,7 +5145,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>works</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.works">works</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -5223,7 +5223,7 @@ MusicBrainz as one release.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="release.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -5232,7 +5232,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="release.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -5241,7 +5241,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>title</strong></td>
+<td colspan="2" valign="top"><strong id="release.title">title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -5250,7 +5250,7 @@ The official title of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="release.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -5259,7 +5259,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="release.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -5269,7 +5269,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artistCredit</strong> ⚠️</td>
+<td colspan="2" valign="top"><strong id="release.artistcredit">artistCredit</strong> ⚠️</td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
 
@@ -5288,7 +5288,7 @@ and will be removed in a major release in the future. Use the equivalent
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artistCredits</strong></td>
+<td colspan="2" valign="top"><strong id="release.artistcredits">artistCredits</strong></td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
 
@@ -5297,7 +5297,7 @@ The main credited artist(s).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releaseEvents</strong></td>
+<td colspan="2" valign="top"><strong id="release.releaseevents">releaseEvents</strong></td>
 <td valign="top">[<a href="#releaseevent">ReleaseEvent</a>]</td>
 <td>
 
@@ -5306,7 +5306,7 @@ The release events for this release.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>date</strong></td>
+<td colspan="2" valign="top"><strong id="release.date">date</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
 
@@ -5317,7 +5317,7 @@ distribution mechanism.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>country</strong></td>
+<td colspan="2" valign="top"><strong id="release.country">country</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -5326,7 +5326,7 @@ The country in which the release was issued.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>asin</strong></td>
+<td colspan="2" valign="top"><strong id="release.asin">asin</strong></td>
 <td valign="top"><a href="#asin">ASIN</a></td>
 <td>
 
@@ -5336,7 +5336,7 @@ of the release.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>barcode</strong></td>
+<td colspan="2" valign="top"><strong id="release.barcode">barcode</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -5348,7 +5348,7 @@ release has one. The most common types found on releases are 12-digit
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>status</strong></td>
+<td colspan="2" valign="top"><strong id="release.status">status</strong></td>
 <td valign="top"><a href="#releasestatus">ReleaseStatus</a></td>
 <td>
 
@@ -5357,7 +5357,7 @@ The status describes how “official” a release is.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>statusID</strong></td>
+<td colspan="2" valign="top"><strong id="release.statusid">statusID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -5367,7 +5367,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>packaging</strong></td>
+<td colspan="2" valign="top"><strong id="release.packaging">packaging</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -5378,7 +5378,7 @@ information.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>packagingID</strong></td>
+<td colspan="2" valign="top"><strong id="release.packagingid">packagingID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -5388,7 +5388,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>quality</strong></td>
+<td colspan="2" valign="top"><strong id="release.quality">quality</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -5399,7 +5399,7 @@ It is not a mark of how good or bad the music itself is – for that, use
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>media</strong></td>
+<td colspan="2" valign="top"><strong id="release.media">media</strong></td>
 <td valign="top">[<a href="#medium">Medium</a>]</td>
 <td>
 
@@ -5408,7 +5408,7 @@ The media on which the release was distributed.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="release.artists">artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
 
@@ -5427,7 +5427,7 @@ A list of artists linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>labels</strong></td>
+<td colspan="2" valign="top"><strong id="release.labels">labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
 
@@ -5446,7 +5446,7 @@ A list of labels linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>recordings</strong></td>
+<td colspan="2" valign="top"><strong id="release.recordings">recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
 
@@ -5465,7 +5465,7 @@ A list of recordings linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releaseGroups</strong></td>
+<td colspan="2" valign="top"><strong id="release.releasegroups">releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
 
@@ -5493,7 +5493,7 @@ Filter by one or more release group types.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="release.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -5502,7 +5502,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="release.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -5521,7 +5521,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="release.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -5557,7 +5557,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="releaseconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -5566,7 +5566,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="releaseconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#releaseedge">ReleaseEdge</a>]</td>
 <td>
 
@@ -5575,7 +5575,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="releaseconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#release">Release</a>]</td>
 <td>
 
@@ -5585,7 +5585,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="releaseconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -5612,7 +5612,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="releaseedge.node">node</strong></td>
 <td valign="top"><a href="#release">Release</a></td>
 <td>
 
@@ -5621,7 +5621,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="releaseedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -5630,7 +5630,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="releaseedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -5658,12 +5658,12 @@ a particular label, catalog number, barcode, and format.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>area</strong></td>
+<td colspan="2" valign="top"><strong id="releaseevent.area">area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>date</strong></td>
+<td colspan="2" valign="top"><strong id="releaseevent.date">date</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td></td>
 </tr>
@@ -5692,7 +5692,7 @@ album – it doesn’t matter how many CDs or editions/versions it had.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -5701,7 +5701,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -5710,7 +5710,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>title</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.title">title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -5719,7 +5719,7 @@ The official title of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -5728,7 +5728,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -5738,7 +5738,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artistCredit</strong> ⚠️</td>
+<td colspan="2" valign="top"><strong id="releasegroup.artistcredit">artistCredit</strong> ⚠️</td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
 
@@ -5757,7 +5757,7 @@ and will be removed in a major release in the future. Use the equivalent
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artistCredits</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.artistcredits">artistCredits</strong></td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
 
@@ -5766,7 +5766,7 @@ The main credited artist(s).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>firstReleaseDate</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.firstreleasedate">firstReleaseDate</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
 
@@ -5775,7 +5775,7 @@ The date of the earliest release in the group.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>primaryType</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.primarytype">primaryType</strong></td>
 <td valign="top"><a href="#releasegrouptype">ReleaseGroupType</a></td>
 <td>
 
@@ -5787,7 +5787,7 @@ e.g. album, single, soundtrack, compilation, etc. A release group can have a
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>primaryTypeID</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.primarytypeid">primaryTypeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -5797,7 +5797,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>secondaryTypes</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.secondarytypes">secondaryTypes</strong></td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
 
@@ -5807,7 +5807,7 @@ that apply to this release group.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>secondaryTypeIDs</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.secondarytypeids">secondaryTypeIDs</strong></td>
 <td valign="top">[<a href="#mbid">MBID</a>]</td>
 <td>
 
@@ -5817,7 +5817,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.artists">artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
 
@@ -5836,7 +5836,7 @@ A list of artists linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -5873,7 +5873,7 @@ Filter by one or more release statuses.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -5882,7 +5882,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -5901,7 +5901,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>rating</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.rating">rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
 
@@ -5910,7 +5910,7 @@ The rating users have given to this entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -5946,7 +5946,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroupconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -5955,7 +5955,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroupconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#releasegroupedge">ReleaseGroupEdge</a>]</td>
 <td>
 
@@ -5964,7 +5964,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroupconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#releasegroup">ReleaseGroup</a>]</td>
 <td>
 
@@ -5974,7 +5974,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroupconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -6001,7 +6001,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroupedge.node">node</strong></td>
 <td valign="top"><a href="#releasegroup">ReleaseGroup</a></td>
 <td>
 
@@ -6010,7 +6010,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroupedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -6019,7 +6019,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroupedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -6046,7 +6046,7 @@ A search for MusicBrainz entities using Lucene query syntax.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>areas</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.areas">areas</strong></td>
 <td valign="top"><a href="#areaconnection">AreaConnection</a></td>
 <td>
 
@@ -6075,7 +6075,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.artists">artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
 
@@ -6104,7 +6104,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>events</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.events">events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
 
@@ -6133,7 +6133,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>instruments</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.instruments">instruments</strong></td>
 <td valign="top"><a href="#instrumentconnection">InstrumentConnection</a></td>
 <td>
 
@@ -6162,7 +6162,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>labels</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.labels">labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
 
@@ -6191,7 +6191,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>places</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.places">places</strong></td>
 <td valign="top"><a href="#placeconnection">PlaceConnection</a></td>
 <td>
 
@@ -6220,7 +6220,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>recordings</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.recordings">recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
 
@@ -6249,7 +6249,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -6278,7 +6278,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releaseGroups</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.releasegroups">releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
 
@@ -6307,7 +6307,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>series</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.series">series</strong></td>
 <td valign="top"><a href="#seriesconnection">SeriesConnection</a></td>
 <td>
 
@@ -6336,7 +6336,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>works</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.works">works</strong></td>
 <td valign="top"><a href="#workconnection">WorkConnection</a></td>
 <td>
 
@@ -6384,7 +6384,7 @@ theme.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="series.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -6393,7 +6393,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="series.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -6402,7 +6402,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="series.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -6411,7 +6411,7 @@ The official name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="series.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -6420,7 +6420,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="series.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -6430,7 +6430,7 @@ contains.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="series.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -6440,7 +6440,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="series.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -6449,7 +6449,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="series.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -6468,7 +6468,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="series.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -6504,7 +6504,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="seriesconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -6513,7 +6513,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="seriesconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#seriesedge">SeriesEdge</a>]</td>
 <td>
 
@@ -6522,7 +6522,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="seriesconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#series">Series</a>]</td>
 <td>
 
@@ -6532,7 +6532,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="seriesconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -6559,7 +6559,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="seriesedge.node">node</strong></td>
 <td valign="top"><a href="#series">Series</a></td>
 <td>
 
@@ -6568,7 +6568,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="seriesedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -6577,7 +6577,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="seriesedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -6606,7 +6606,7 @@ release, or recording.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="tag.name">name</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -6615,7 +6615,7 @@ The tag label.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>count</strong></td>
+<td colspan="2" valign="top"><strong id="tag.count">count</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -6641,7 +6641,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="tagconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -6650,7 +6650,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="tagconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#tagedge">TagEdge</a>]</td>
 <td>
 
@@ -6659,7 +6659,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="tagconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#tag">Tag</a>]</td>
 <td>
 
@@ -6669,7 +6669,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="tagconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -6696,7 +6696,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="tagedge.node">node</strong></td>
 <td valign="top"><a href="#tag">Tag</a></td>
 <td>
 
@@ -6705,7 +6705,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="tagedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -6714,7 +6714,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="tagedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -6743,7 +6743,7 @@ A track is the way a recording is represented on a particular
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="track.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -6752,7 +6752,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>title</strong></td>
+<td colspan="2" valign="top"><strong id="track.title">title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -6761,7 +6761,7 @@ The official title of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>position</strong></td>
+<td colspan="2" valign="top"><strong id="track.position">position</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -6771,7 +6771,7 @@ tracks from all discs).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>number</strong></td>
+<td colspan="2" valign="top"><strong id="track.number">number</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -6781,7 +6781,7 @@ disc or side it appears on, e.g. “A1” or “B3”.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>length</strong></td>
+<td colspan="2" valign="top"><strong id="track.length">length</strong></td>
 <td valign="top"><a href="#duration">Duration</a></td>
 <td>
 
@@ -6790,7 +6790,7 @@ The length of the track.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>recording</strong></td>
+<td colspan="2" valign="top"><strong id="track.recording">recording</strong></td>
 <td valign="top"><a href="#recording">Recording</a></td>
 <td>
 
@@ -6818,7 +6818,7 @@ acquired, an entry in another database, etc.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="url.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -6827,7 +6827,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="url.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -6836,7 +6836,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>resource</strong></td>
+<td colspan="2" valign="top"><strong id="url.resource">resource</strong></td>
 <td valign="top"><a href="#urlstring">URLString</a>!</td>
 <td>
 
@@ -6845,7 +6845,7 @@ The actual URL string.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="url.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -6873,7 +6873,7 @@ more audio recordings.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="work.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -6882,7 +6882,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="work.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -6891,7 +6891,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>title</strong></td>
+<td colspan="2" valign="top"><strong id="work.title">title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -6900,7 +6900,7 @@ The official title of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="work.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -6909,7 +6909,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="work.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -6919,7 +6919,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>iswcs</strong></td>
+<td colspan="2" valign="top"><strong id="work.iswcs">iswcs</strong></td>
 <td valign="top">[<a href="#string">String</a>]</td>
 <td>
 
@@ -6929,7 +6929,7 @@ to the work by copyright collecting agencies.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>language</strong></td>
+<td colspan="2" valign="top"><strong id="work.language">language</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -6938,7 +6938,7 @@ The language in which the work was originally written.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="work.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -6947,7 +6947,7 @@ The type of work.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="work.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -6957,7 +6957,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="work.artists">artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
 
@@ -6976,7 +6976,7 @@ A list of artists linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="work.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -6985,7 +6985,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="work.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -7004,7 +7004,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>rating</strong></td>
+<td colspan="2" valign="top"><strong id="work.rating">rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
 
@@ -7013,7 +7013,7 @@ The rating users have given to this entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="work.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -7049,7 +7049,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="workconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -7058,7 +7058,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="workconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#workedge">WorkEdge</a>]</td>
 <td>
 
@@ -7067,7 +7067,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="workconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#work">Work</a>]</td>
 <td>
 
@@ -7077,7 +7077,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="workconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -7104,7 +7104,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="workedge.node">node</strong></td>
 <td valign="top"><a href="#work">Work</a></td>
 <td>
 
@@ -7113,7 +7113,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="workedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -7122,7 +7122,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="workedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -7487,7 +7487,7 @@ An entity in the MusicBrainz schema.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="entity.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -7513,7 +7513,7 @@ An object with an ID
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="node.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 

--- a/test/fixtures/graphbrainz-updateSchema-updated.md
+++ b/test/fixtures/graphbrainz-updateSchema-updated.md
@@ -111,7 +111,7 @@ requests can be made.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>lookup</strong></td>
+<td colspan="2" valign="top"><strong id="query.lookup">lookup</strong></td>
 <td valign="top"><a href="#lookupquery">LookupQuery</a></td>
 <td>
 
@@ -120,7 +120,7 @@ Perform a lookup of a MusicBrainz entity by its MBID.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>browse</strong></td>
+<td colspan="2" valign="top"><strong id="query.browse">browse</strong></td>
 <td valign="top"><a href="#browsequery">BrowseQuery</a></td>
 <td>
 
@@ -129,7 +129,7 @@ Browse all MusicBrainz entities directly linked to another entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>search</strong></td>
+<td colspan="2" valign="top"><strong id="query.search">search</strong></td>
 <td valign="top"><a href="#searchquery">SearchQuery</a></td>
 <td>
 
@@ -138,7 +138,7 @@ Search for MusicBrainz entities using Lucene query syntax.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="query.node">node</strong></td>
 <td valign="top"><a href="#node">Node</a></td>
 <td>
 
@@ -177,7 +177,7 @@ entity will be given as a result – even if the actual name wouldn’t be.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="alias.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -186,7 +186,7 @@ The aliased name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>sortName</strong></td>
+<td colspan="2" valign="top"><strong id="alias.sortname">sortName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -197,7 +197,7 @@ the front).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>locale</strong></td>
+<td colspan="2" valign="top"><strong id="alias.locale">locale</strong></td>
 <td valign="top"><a href="#locale">Locale</a></td>
 <td>
 
@@ -207,7 +207,7 @@ used.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>primary</strong></td>
+<td colspan="2" valign="top"><strong id="alias.primary">primary</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
 
@@ -217,7 +217,7 @@ specified locale (this could mean the most recent or the most common).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="alias.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -227,7 +227,7 @@ search hint, etc.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="alias.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -255,7 +255,7 @@ or settlements (countries, cities, or the like).
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="area.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -264,7 +264,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="area.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -273,7 +273,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="area.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -282,7 +282,7 @@ The official name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>sortName</strong></td>
+<td colspan="2" valign="top"><strong id="area.sortname">sortName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -293,7 +293,7 @@ the front).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="area.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -302,7 +302,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="area.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -312,7 +312,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>isoCodes</strong></td>
+<td colspan="2" valign="top"><strong id="area.isocodes">isoCodes</strong></td>
 <td valign="top">[<a href="#string">String</a>]</td>
 <td>
 
@@ -332,7 +332,7 @@ Available ISO standards are 3166-1, 3166-2, and 3166-3.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="area.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -342,7 +342,7 @@ values](https://musicbrainz.org/doc/Area)).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="area.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -352,7 +352,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="area.artists">artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
 
@@ -371,7 +371,7 @@ A list of artists linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>events</strong></td>
+<td colspan="2" valign="top"><strong id="area.events">events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
 
@@ -390,7 +390,7 @@ A list of events linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>labels</strong></td>
+<td colspan="2" valign="top"><strong id="area.labels">labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
 
@@ -409,7 +409,7 @@ A list of labels linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>places</strong></td>
+<td colspan="2" valign="top"><strong id="area.places">places</strong></td>
 <td valign="top"><a href="#placeconnection">PlaceConnection</a></td>
 <td>
 
@@ -428,7 +428,7 @@ A list of places linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="area.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -465,7 +465,7 @@ Filter by one or more release statuses.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="area.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -474,7 +474,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="area.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -493,7 +493,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="area.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -529,7 +529,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="areaconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -538,7 +538,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="areaconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#areaedge">AreaEdge</a>]</td>
 <td>
 
@@ -547,7 +547,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="areaconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#area">Area</a>]</td>
 <td>
 
@@ -557,7 +557,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="areaconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -584,7 +584,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="areaedge.node">node</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
 
@@ -593,7 +593,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="areaedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -602,7 +602,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="areaedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -633,7 +633,7 @@ even a fictional character.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="artist.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -642,7 +642,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="artist.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -651,7 +651,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="artist.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -660,7 +660,7 @@ The official name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>sortName</strong></td>
+<td colspan="2" valign="top"><strong id="artist.sortname">sortName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -671,7 +671,7 @@ the front).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="artist.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -680,7 +680,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="artist.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -690,7 +690,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>country</strong></td>
+<td colspan="2" valign="top"><strong id="artist.country">country</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -700,7 +700,7 @@ is often, but not always, its birth/formation country.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>area</strong></td>
+<td colspan="2" valign="top"><strong id="artist.area">area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
 
@@ -710,7 +710,7 @@ is often, but not always, its birth/formation country.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>beginArea</strong></td>
+<td colspan="2" valign="top"><strong id="artist.beginarea">beginArea</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
 
@@ -720,7 +720,7 @@ they were born, if the artist is a person).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>endArea</strong></td>
+<td colspan="2" valign="top"><strong id="artist.endarea">endArea</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
 
@@ -730,7 +730,7 @@ they died, if the artist is a person).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>lifeSpan</strong></td>
+<td colspan="2" valign="top"><strong id="artist.lifespan">lifeSpan</strong></td>
 <td valign="top"><a href="#lifespan">LifeSpan</a></td>
 <td>
 
@@ -740,7 +740,7 @@ meaning depends on the type of entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>gender</strong></td>
+<td colspan="2" valign="top"><strong id="artist.gender">gender</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -750,7 +750,7 @@ neither. Groups do not have genders.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>genderID</strong></td>
+<td colspan="2" valign="top"><strong id="artist.genderid">genderID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -760,7 +760,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="artist.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -769,7 +769,7 @@ Whether an artist is a person, a group, or something else.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="artist.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -779,7 +779,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>ipis</strong></td>
+<td colspan="2" valign="top"><strong id="artist.ipis">ipis</strong></td>
 <td valign="top">[<a href="#ipi">IPI</a>]</td>
 <td>
 
@@ -789,7 +789,7 @@ List of [Interested Parties Information](https://musicbrainz.org/doc/IPI)
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>isnis</strong></td>
+<td colspan="2" valign="top"><strong id="artist.isnis">isnis</strong></td>
 <td valign="top">[<a href="#isni">ISNI</a>]</td>
 <td>
 
@@ -799,7 +799,7 @@ List of [International Standard Name Identifier](https://musicbrainz.org/doc/ISN
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>recordings</strong></td>
+<td colspan="2" valign="top"><strong id="artist.recordings">recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
 
@@ -818,7 +818,7 @@ A list of recordings linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="artist.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -855,7 +855,7 @@ Filter by one or more release statuses.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releaseGroups</strong></td>
+<td colspan="2" valign="top"><strong id="artist.releasegroups">releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
 
@@ -883,7 +883,7 @@ Filter by one or more release group types.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>works</strong></td>
+<td colspan="2" valign="top"><strong id="artist.works">works</strong></td>
 <td valign="top"><a href="#workconnection">WorkConnection</a></td>
 <td>
 
@@ -902,7 +902,7 @@ A list of works linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="artist.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -911,7 +911,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="artist.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -930,7 +930,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>rating</strong></td>
+<td colspan="2" valign="top"><strong id="artist.rating">rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
 
@@ -939,7 +939,7 @@ The rating users have given to this entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="artist.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -975,7 +975,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="artistconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -984,7 +984,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="artistconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#artistedge">ArtistEdge</a>]</td>
 <td>
 
@@ -993,7 +993,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="artistconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#artist">Artist</a>]</td>
 <td>
 
@@ -1003,7 +1003,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="artistconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -1034,7 +1034,7 @@ track, etc., and join phrases between them.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>artist</strong></td>
+<td colspan="2" valign="top"><strong id="artistcredit.artist">artist</strong></td>
 <td valign="top"><a href="#artist">Artist</a></td>
 <td>
 
@@ -1044,7 +1044,7 @@ credits.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="artistcredit.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -1054,7 +1054,7 @@ track, etc.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>joinPhrase</strong></td>
+<td colspan="2" valign="top"><strong id="artistcredit.joinphrase">joinPhrase</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -1081,7 +1081,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="artistedge.node">node</strong></td>
 <td valign="top"><a href="#artist">Artist</a></td>
 <td>
 
@@ -1090,7 +1090,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="artistedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -1099,7 +1099,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="artistedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -1127,7 +1127,7 @@ entity.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>areas</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.areas">areas</strong></td>
 <td valign="top"><a href="#areaconnection">AreaConnection</a></td>
 <td>
 
@@ -1155,7 +1155,7 @@ The MBID of a collection in which the entity is found.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.artists">artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
 
@@ -1228,7 +1228,7 @@ The MBID of a work to which the entity is linked.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -1337,7 +1337,7 @@ The MBID of a work to which the entity is linked.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>events</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.events">events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
 
@@ -1392,7 +1392,7 @@ The MBID of a place to which the entity is linked.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>labels</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.labels">labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
 
@@ -1438,7 +1438,7 @@ The MBID of a release to which the entity is linked.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>places</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.places">places</strong></td>
 <td valign="top"><a href="#placeconnection">PlaceConnection</a></td>
 <td>
 
@@ -1475,7 +1475,7 @@ The MBID of a collection in which the entity is found.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>recordings</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.recordings">recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
 
@@ -1531,7 +1531,7 @@ The MBID of a release to which the entity is linked.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -1651,7 +1651,7 @@ Filter by one or more release statuses.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releaseGroups</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.releasegroups">releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
 
@@ -1706,7 +1706,7 @@ Filter by one or more release group types.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>works</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.works">works</strong></td>
 <td valign="top"><a href="#workconnection">WorkConnection</a></td>
 <td>
 
@@ -1771,7 +1771,7 @@ lists of entities that users can create.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="collection.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -1780,7 +1780,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="collection.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -1789,7 +1789,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="collection.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -1798,7 +1798,7 @@ The official name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>editor</strong></td>
+<td colspan="2" valign="top"><strong id="collection.editor">editor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -1807,7 +1807,7 @@ The username of the editor who created the collection.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>entityType</strong></td>
+<td colspan="2" valign="top"><strong id="collection.entitytype">entityType</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -1816,7 +1816,7 @@ The type of entity listed in the collection.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="collection.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -1825,7 +1825,7 @@ The type of collection.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="collection.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -1835,7 +1835,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>areas</strong></td>
+<td colspan="2" valign="top"><strong id="collection.areas">areas</strong></td>
 <td valign="top"><a href="#areaconnection">AreaConnection</a></td>
 <td>
 
@@ -1854,7 +1854,7 @@ The list of areas found in this collection.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="collection.artists">artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
 
@@ -1873,7 +1873,7 @@ The list of artists found in this collection.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>events</strong></td>
+<td colspan="2" valign="top"><strong id="collection.events">events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
 
@@ -1892,7 +1892,7 @@ The list of events found in this collection.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>instruments</strong></td>
+<td colspan="2" valign="top"><strong id="collection.instruments">instruments</strong></td>
 <td valign="top"><a href="#instrumentconnection">InstrumentConnection</a></td>
 <td>
 
@@ -1911,7 +1911,7 @@ The list of instruments found in this collection.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>labels</strong></td>
+<td colspan="2" valign="top"><strong id="collection.labels">labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
 
@@ -1930,7 +1930,7 @@ The list of labels found in this collection.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>places</strong></td>
+<td colspan="2" valign="top"><strong id="collection.places">places</strong></td>
 <td valign="top"><a href="#placeconnection">PlaceConnection</a></td>
 <td>
 
@@ -1949,7 +1949,7 @@ The list of places found in this collection.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>recordings</strong></td>
+<td colspan="2" valign="top"><strong id="collection.recordings">recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
 
@@ -1968,7 +1968,7 @@ The list of recordings found in this collection.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="collection.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -2005,7 +2005,7 @@ Filter by one or more release statuses.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releaseGroups</strong></td>
+<td colspan="2" valign="top"><strong id="collection.releasegroups">releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
 
@@ -2033,7 +2033,7 @@ Filter by one or more release group types.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>series</strong></td>
+<td colspan="2" valign="top"><strong id="collection.series">series</strong></td>
 <td valign="top"><a href="#seriesconnection">SeriesConnection</a></td>
 <td>
 
@@ -2052,7 +2052,7 @@ The list of series found in this collection.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>works</strong></td>
+<td colspan="2" valign="top"><strong id="collection.works">works</strong></td>
 <td valign="top"><a href="#workconnection">WorkConnection</a></td>
 <td>
 
@@ -2088,7 +2088,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="collectionconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -2097,7 +2097,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="collectionconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#collectionedge">CollectionEdge</a>]</td>
 <td>
 
@@ -2106,7 +2106,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="collectionconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#collection">Collection</a>]</td>
 <td>
 
@@ -2116,7 +2116,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="collectionconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -2143,7 +2143,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="collectionedge.node">node</strong></td>
 <td valign="top"><a href="#collection">Collection</a></td>
 <td>
 
@@ -2152,7 +2152,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="collectionedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -2161,7 +2161,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="collectionedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -2188,7 +2188,7 @@ Geographic coordinates described with latitude and longitude.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>latitude</strong></td>
+<td colspan="2" valign="top"><strong id="coordinates.latitude">latitude</strong></td>
 <td valign="top"><a href="#degrees">Degrees</a></td>
 <td>
 
@@ -2197,7 +2197,7 @@ The north–south position of a point on the Earth’s surface.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>longitude</strong></td>
+<td colspan="2" valign="top"><strong id="coordinates.longitude">longitude</strong></td>
 <td valign="top"><a href="#degrees">Degrees</a></td>
 <td>
 
@@ -2223,7 +2223,7 @@ An individual piece of album artwork from the [Cover Art Archive](https://musicb
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>fileID</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiveimage.fileid">fileID</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -2232,7 +2232,7 @@ The Internet Archive’s internal file ID for the image.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>image</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiveimage.image">image</strong></td>
 <td valign="top"><a href="#urlstring">URLString</a>!</td>
 <td>
 
@@ -2241,7 +2241,7 @@ The URL at which the image can be found.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>thumbnails</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiveimage.thumbnails">thumbnails</strong></td>
 <td valign="top"><a href="#coverartarchiveimagethumbnails">CoverArtArchiveImageThumbnails</a>!</td>
 <td>
 
@@ -2250,7 +2250,7 @@ A set of thumbnails for the image.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>front</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiveimage.front">front</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a>!</td>
 <td>
 
@@ -2259,7 +2259,7 @@ Whether this image depicts the “main front” of the release.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>back</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiveimage.back">back</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a>!</td>
 <td>
 
@@ -2268,7 +2268,7 @@ Whether this image depicts the “main back” of the release.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>types</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiveimage.types">types</strong></td>
 <td valign="top">[<a href="#string">String</a>]!</td>
 <td>
 
@@ -2278,7 +2278,7 @@ describing what part(s) of the release the image includes.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edit</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiveimage.edit">edit</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -2287,7 +2287,7 @@ The MusicBrainz edit ID.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>approved</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiveimage.approved">approved</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
 
@@ -2296,7 +2296,7 @@ Whether the image was approved by the MusicBrainz edit system.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>comment</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiveimage.comment">comment</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2322,7 +2322,7 @@ URLs for thumbnails of different sizes for a particular piece of cover art.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>small</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiveimagethumbnails.small">small</strong></td>
 <td valign="top"><a href="#urlstring">URLString</a></td>
 <td>
 
@@ -2332,7 +2332,7 @@ The URL of a small version of the cover art, where the maximum dimension is
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>large</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiveimagethumbnails.large">large</strong></td>
 <td valign="top"><a href="#urlstring">URLString</a></td>
 <td>
 
@@ -2361,7 +2361,7 @@ as well as a summary of what artwork is available.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>front</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiverelease.front">front</strong></td>
 <td valign="top"><a href="#urlstring">URLString</a></td>
 <td>
 
@@ -2388,7 +2388,7 @@ retrieved as well.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>back</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiverelease.back">back</strong></td>
 <td valign="top"><a href="#urlstring">URLString</a></td>
 <td>
 
@@ -2414,7 +2414,7 @@ retrieved as well.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>images</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiverelease.images">images</strong></td>
 <td valign="top">[<a href="#coverartarchiveimage">CoverArtArchiveImage</a>]!</td>
 <td>
 
@@ -2424,7 +2424,7 @@ media and packaging.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artwork</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiverelease.artwork">artwork</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a>!</td>
 <td>
 
@@ -2433,7 +2433,7 @@ Whether there is artwork present for this release.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>count</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiverelease.count">count</strong></td>
 <td valign="top"><a href="#int">Int</a>!</td>
 <td>
 
@@ -2442,7 +2442,7 @@ The number of artwork images present for this release.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>release</strong></td>
+<td colspan="2" valign="top"><strong id="coverartarchiverelease.release">release</strong></td>
 <td valign="top"><a href="#release">Release</a></td>
 <td>
 
@@ -2469,7 +2469,7 @@ particular [disc ID](https://musicbrainz.org/doc/Disc_ID).
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="disc.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -2478,7 +2478,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>discID</strong></td>
+<td colspan="2" valign="top"><strong id="disc.discid">discID</strong></td>
 <td valign="top"><a href="#discid">DiscID</a>!</td>
 <td>
 
@@ -2487,7 +2487,7 @@ The [disc ID](https://musicbrainz.org/doc/Disc_ID) of this disc.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>offsetCount</strong></td>
+<td colspan="2" valign="top"><strong id="disc.offsetcount">offsetCount</strong></td>
 <td valign="top"><a href="#int">Int</a>!</td>
 <td>
 
@@ -2496,7 +2496,7 @@ The number of offsets (tracks) on the disc.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>offsets</strong></td>
+<td colspan="2" valign="top"><strong id="disc.offsets">offsets</strong></td>
 <td valign="top">[<a href="#int">Int</a>]</td>
 <td>
 
@@ -2505,7 +2505,7 @@ The sector offset of each track on the disc.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>sectors</strong></td>
+<td colspan="2" valign="top"><strong id="disc.sectors">sectors</strong></td>
 <td valign="top"><a href="#int">Int</a>!</td>
 <td>
 
@@ -2514,7 +2514,7 @@ The sector offset of the lead-out (the end of the disc).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="disc.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -2552,7 +2552,7 @@ Generally this means live performances, like concerts and festivals.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="event.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -2561,7 +2561,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="event.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -2570,7 +2570,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="event.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2579,7 +2579,7 @@ The official name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="event.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2588,7 +2588,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="event.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -2598,7 +2598,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>lifeSpan</strong></td>
+<td colspan="2" valign="top"><strong id="event.lifespan">lifeSpan</strong></td>
 <td valign="top"><a href="#lifespan">LifeSpan</a></td>
 <td>
 
@@ -2608,7 +2608,7 @@ meaning depends on the type of entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>time</strong></td>
+<td colspan="2" valign="top"><strong id="event.time">time</strong></td>
 <td valign="top"><a href="#time">Time</a></td>
 <td>
 
@@ -2617,7 +2617,7 @@ The start time of the event.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cancelled</strong></td>
+<td colspan="2" valign="top"><strong id="event.cancelled">cancelled</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
 
@@ -2626,7 +2626,7 @@ Whether or not the event took place.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>setlist</strong></td>
+<td colspan="2" valign="top"><strong id="event.setlist">setlist</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2637,7 +2637,7 @@ for syntax and examples.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="event.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2646,7 +2646,7 @@ What kind of event the event is, e.g. concert, festival, etc.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="event.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -2656,7 +2656,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="event.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -2665,7 +2665,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="event.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -2684,7 +2684,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>rating</strong></td>
+<td colspan="2" valign="top"><strong id="event.rating">rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
 
@@ -2693,7 +2693,7 @@ The rating users have given to this entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="event.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -2729,7 +2729,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="eventconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -2738,7 +2738,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="eventconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#eventedge">EventEdge</a>]</td>
 <td>
 
@@ -2747,7 +2747,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="eventconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#event">Event</a>]</td>
 <td>
 
@@ -2757,7 +2757,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="eventconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -2784,7 +2784,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="eventedge.node">node</strong></td>
 <td valign="top"><a href="#event">Event</a></td>
 <td>
 
@@ -2793,7 +2793,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="eventedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -2802,7 +2802,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="eventedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -2831,7 +2831,7 @@ used in relationships between two other entities.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -2840,7 +2840,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -2849,7 +2849,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2858,7 +2858,7 @@ The official name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2867,7 +2867,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -2877,7 +2877,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>description</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.description">description</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2887,7 +2887,7 @@ instrument.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2898,7 +2898,7 @@ classification.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -2908,7 +2908,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -2917,7 +2917,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -2936,7 +2936,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -2972,7 +2972,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="instrumentconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -2981,7 +2981,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="instrumentconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#instrumentedge">InstrumentEdge</a>]</td>
 <td>
 
@@ -2990,7 +2990,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="instrumentconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#instrument">Instrument</a>]</td>
 <td>
 
@@ -3000,7 +3000,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="instrumentconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -3027,7 +3027,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="instrumentedge.node">node</strong></td>
 <td valign="top"><a href="#instrument">Instrument</a></td>
 <td>
 
@@ -3036,7 +3036,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="instrumentedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -3045,7 +3045,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="instrumentedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -3074,7 +3074,7 @@ represent a record company.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="label.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -3083,7 +3083,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="label.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -3092,7 +3092,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="label.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3101,7 +3101,7 @@ The official name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>sortName</strong></td>
+<td colspan="2" valign="top"><strong id="label.sortname">sortName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3112,7 +3112,7 @@ the front).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="label.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3121,7 +3121,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="label.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -3131,7 +3131,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>country</strong></td>
+<td colspan="2" valign="top"><strong id="label.country">country</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3140,7 +3140,7 @@ The country of origin for the label.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>area</strong></td>
+<td colspan="2" valign="top"><strong id="label.area">area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
 
@@ -3149,7 +3149,7 @@ The area in which the label is based.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>lifeSpan</strong></td>
+<td colspan="2" valign="top"><strong id="label.lifespan">lifeSpan</strong></td>
 <td valign="top"><a href="#lifespan">LifeSpan</a></td>
 <td>
 
@@ -3159,7 +3159,7 @@ meaning depends on the type of entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>labelCode</strong></td>
+<td colspan="2" valign="top"><strong id="label.labelcode">labelCode</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -3169,7 +3169,7 @@ of the label.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>ipis</strong></td>
+<td colspan="2" valign="top"><strong id="label.ipis">ipis</strong></td>
 <td valign="top">[<a href="#ipi">IPI</a>]</td>
 <td>
 
@@ -3179,7 +3179,7 @@ codes for the label.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="label.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3189,7 +3189,7 @@ imprint, production, distributor, rights society, etc.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="label.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -3199,7 +3199,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="label.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -3236,7 +3236,7 @@ Filter by one or more release statuses.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="label.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -3245,7 +3245,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="label.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -3264,7 +3264,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>rating</strong></td>
+<td colspan="2" valign="top"><strong id="label.rating">rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
 
@@ -3273,7 +3273,7 @@ The rating users have given to this entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="label.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -3309,7 +3309,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="labelconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -3318,7 +3318,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="labelconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#labeledge">LabelEdge</a>]</td>
 <td>
 
@@ -3327,7 +3327,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="labelconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#label">Label</a>]</td>
 <td>
 
@@ -3337,7 +3337,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="labelconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -3364,7 +3364,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="labeledge.node">node</strong></td>
 <td valign="top"><a href="#label">Label</a></td>
 <td>
 
@@ -3373,7 +3373,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="labeledge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -3382,7 +3382,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="labeledge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -3410,7 +3410,7 @@ lifetime, including whether it has ended (even if the date is unknown).
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>begin</strong></td>
+<td colspan="2" valign="top"><strong id="lifespan.begin">begin</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
 
@@ -3419,7 +3419,7 @@ The start date of the entity’s life span.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>end</strong></td>
+<td colspan="2" valign="top"><strong id="lifespan.end">end</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
 
@@ -3428,7 +3428,7 @@ The end date of the entity’s life span.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>ended</strong></td>
+<td colspan="2" valign="top"><strong id="lifespan.ended">ended</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
 
@@ -3454,7 +3454,7 @@ A lookup of an individual MusicBrainz entity by its MBID.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>area</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.area">area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
 
@@ -3472,7 +3472,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artist</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.artist">artist</strong></td>
 <td valign="top"><a href="#artist">Artist</a></td>
 <td>
 
@@ -3490,7 +3490,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collection</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.collection">collection</strong></td>
 <td valign="top"><a href="#collection">Collection</a></td>
 <td>
 
@@ -3508,7 +3508,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disc</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.disc">disc</strong></td>
 <td valign="top"><a href="#disc">Disc</a></td>
 <td>
 
@@ -3527,7 +3527,7 @@ of the disc.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>event</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.event">event</strong></td>
 <td valign="top"><a href="#event">Event</a></td>
 <td>
 
@@ -3545,7 +3545,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>instrument</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.instrument">instrument</strong></td>
 <td valign="top"><a href="#instrument">Instrument</a></td>
 <td>
 
@@ -3563,7 +3563,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>label</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.label">label</strong></td>
 <td valign="top"><a href="#label">Label</a></td>
 <td>
 
@@ -3581,7 +3581,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>place</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.place">place</strong></td>
 <td valign="top"><a href="#place">Place</a></td>
 <td>
 
@@ -3599,7 +3599,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>recording</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.recording">recording</strong></td>
 <td valign="top"><a href="#recording">Recording</a></td>
 <td>
 
@@ -3617,7 +3617,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>release</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.release">release</strong></td>
 <td valign="top"><a href="#release">Release</a></td>
 <td>
 
@@ -3635,7 +3635,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releaseGroup</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.releasegroup">releaseGroup</strong></td>
 <td valign="top"><a href="#releasegroup">ReleaseGroup</a></td>
 <td>
 
@@ -3653,7 +3653,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>series</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.series">series</strong></td>
 <td valign="top"><a href="#series">Series</a></td>
 <td>
 
@@ -3671,7 +3671,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>url</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.url">url</strong></td>
 <td valign="top"><a href="#url">URL</a></td>
 <td>
 
@@ -3698,7 +3698,7 @@ The web address of the URL entity to look up.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>work</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.work">work</strong></td>
 <td valign="top"><a href="#work">Work</a></td>
 <td>
 
@@ -3737,7 +3737,7 @@ cassette) and can optionally also have a title.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>title</strong></td>
+<td colspan="2" valign="top"><strong id="medium.title">title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3746,7 +3746,7 @@ The title of this particular medium.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>format</strong></td>
+<td colspan="2" valign="top"><strong id="medium.format">format</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3756,7 +3756,7 @@ the medium (e.g. CD, DVD, vinyl, cassette).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>formatID</strong></td>
+<td colspan="2" valign="top"><strong id="medium.formatid">formatID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -3766,7 +3766,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>position</strong></td>
+<td colspan="2" valign="top"><strong id="medium.position">position</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -3776,7 +3776,7 @@ multi-disc release).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>trackCount</strong></td>
+<td colspan="2" valign="top"><strong id="medium.trackcount">trackCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -3785,7 +3785,7 @@ The number of audio tracks on this medium.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>discs</strong></td>
+<td colspan="2" valign="top"><strong id="medium.discs">discs</strong></td>
 <td valign="top">[<a href="#disc">Disc</a>]</td>
 <td>
 
@@ -3794,7 +3794,7 @@ A list of physical discs and their disc IDs for this medium.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tracks</strong></td>
+<td colspan="2" valign="top"><strong id="medium.tracks">tracks</strong></td>
 <td valign="top">[<a href="#track">Track</a>]</td>
 <td>
 
@@ -3820,7 +3820,7 @@ Information about pagination in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>hasNextPage</strong></td>
+<td colspan="2" valign="top"><strong id="pageinfo.hasnextpage">hasNextPage</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a>!</td>
 <td>
 
@@ -3829,7 +3829,7 @@ When paginating forwards, are there more items?
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>hasPreviousPage</strong></td>
+<td colspan="2" valign="top"><strong id="pageinfo.haspreviouspage">hasPreviousPage</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a>!</td>
 <td>
 
@@ -3838,7 +3838,7 @@ When paginating backwards, are there more items?
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>startCursor</strong></td>
+<td colspan="2" valign="top"><strong id="pageinfo.startcursor">startCursor</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3847,7 +3847,7 @@ When paginating backwards, the cursor to continue.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>endCursor</strong></td>
+<td colspan="2" valign="top"><strong id="pageinfo.endcursor">endCursor</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3874,7 +3874,7 @@ or other place where music is performed, recorded, engineered, etc.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="place.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -3883,7 +3883,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="place.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -3892,7 +3892,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="place.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3901,7 +3901,7 @@ The official name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="place.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3910,7 +3910,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="place.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -3920,7 +3920,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>address</strong></td>
+<td colspan="2" valign="top"><strong id="place.address">address</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3930,7 +3930,7 @@ standard addressing format for the country it is located in.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>area</strong></td>
+<td colspan="2" valign="top"><strong id="place.area">area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
 
@@ -3940,7 +3940,7 @@ which the place is located.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>coordinates</strong></td>
+<td colspan="2" valign="top"><strong id="place.coordinates">coordinates</strong></td>
 <td valign="top"><a href="#coordinates">Coordinates</a></td>
 <td>
 
@@ -3949,7 +3949,7 @@ The geographic coordinates of the place.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>lifeSpan</strong></td>
+<td colspan="2" valign="top"><strong id="place.lifespan">lifeSpan</strong></td>
 <td valign="top"><a href="#lifespan">LifeSpan</a></td>
 <td>
 
@@ -3959,7 +3959,7 @@ meaning depends on the type of entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="place.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3969,7 +3969,7 @@ function.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="place.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -3979,7 +3979,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>events</strong></td>
+<td colspan="2" valign="top"><strong id="place.events">events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
 
@@ -3998,7 +3998,7 @@ A list of events linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="place.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -4007,7 +4007,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="place.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -4026,7 +4026,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="place.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -4062,7 +4062,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="placeconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -4071,7 +4071,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="placeconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#placeedge">PlaceEdge</a>]</td>
 <td>
 
@@ -4080,7 +4080,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="placeconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#place">Place</a>]</td>
 <td>
 
@@ -4090,7 +4090,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="placeconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -4117,7 +4117,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="placeedge.node">node</strong></td>
 <td valign="top"><a href="#place">Place</a></td>
 <td>
 
@@ -4126,7 +4126,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="placeedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -4135,7 +4135,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="placeedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -4165,7 +4165,7 @@ for the entity.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>voteCount</strong></td>
+<td colspan="2" valign="top"><strong id="rating.votecount">voteCount</strong></td>
 <td valign="top"><a href="#int">Int</a>!</td>
 <td>
 
@@ -4174,7 +4174,7 @@ The number of votes that have contributed to the rating.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>value</strong></td>
+<td colspan="2" valign="top"><strong id="rating.value">value</strong></td>
 <td valign="top"><a href="#float">Float</a></td>
 <td>
 
@@ -4211,7 +4211,7 @@ or mixing.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="recording.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -4220,7 +4220,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="recording.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -4229,7 +4229,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>title</strong></td>
+<td colspan="2" valign="top"><strong id="recording.title">title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -4238,7 +4238,7 @@ The official title of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="recording.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -4247,7 +4247,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="recording.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -4257,7 +4257,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artistCredit</strong> ⚠️</td>
+<td colspan="2" valign="top"><strong id="recording.artistcredit">artistCredit</strong> ⚠️</td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
 
@@ -4276,7 +4276,7 @@ and will be removed in a major release in the future. Use the equivalent
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artistCredits</strong></td>
+<td colspan="2" valign="top"><strong id="recording.artistcredits">artistCredits</strong></td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
 
@@ -4285,7 +4285,7 @@ The main credited artist(s).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>isrcs</strong></td>
+<td colspan="2" valign="top"><strong id="recording.isrcs">isrcs</strong></td>
 <td valign="top">[<a href="#isrc">ISRC</a>]</td>
 <td>
 
@@ -4295,7 +4295,7 @@ A list of [International Standard Recording Codes](https://musicbrainz.org/doc/I
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>length</strong></td>
+<td colspan="2" valign="top"><strong id="recording.length">length</strong></td>
 <td valign="top"><a href="#duration">Duration</a></td>
 <td>
 
@@ -4305,7 +4305,7 @@ from the lengths of the tracks using it.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>video</strong></td>
+<td colspan="2" valign="top"><strong id="recording.video">video</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
 
@@ -4314,7 +4314,7 @@ Whether this is a video recording.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="recording.artists">artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
 
@@ -4333,7 +4333,7 @@ A list of artists linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="recording.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -4370,7 +4370,7 @@ Filter by one or more release statuses.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="recording.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -4379,7 +4379,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="recording.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -4398,7 +4398,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>rating</strong></td>
+<td colspan="2" valign="top"><strong id="recording.rating">rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
 
@@ -4407,7 +4407,7 @@ The rating users have given to this entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="recording.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -4443,7 +4443,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="recordingconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -4452,7 +4452,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="recordingconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#recordingedge">RecordingEdge</a>]</td>
 <td>
 
@@ -4461,7 +4461,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="recordingconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#recording">Recording</a>]</td>
 <td>
 
@@ -4471,7 +4471,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="recordingconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -4498,7 +4498,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="recordingedge.node">node</strong></td>
 <td valign="top"><a href="#recording">Recording</a></td>
 <td>
 
@@ -4507,7 +4507,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="recordingedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -4516,7 +4516,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="recordingedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -4545,7 +4545,7 @@ other and to URLs outside MusicBrainz.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>target</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.target">target</strong></td>
 <td valign="top"><a href="#entity">Entity</a>!</td>
 <td>
 
@@ -4554,7 +4554,7 @@ The target entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>direction</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.direction">direction</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -4563,7 +4563,7 @@ The direction of the relationship.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>targetType</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.targettype">targetType</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -4572,7 +4572,7 @@ The type of entity on the receiving end of the relationship.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>sourceCredit</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.sourcecredit">sourceCredit</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -4582,7 +4582,7 @@ from its main (performance) name.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>targetCredit</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.targetcredit">targetCredit</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -4592,7 +4592,7 @@ from its main (performance) name.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>begin</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.begin">begin</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
 
@@ -4601,7 +4601,7 @@ The date on which the relationship became applicable.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>end</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.end">end</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
 
@@ -4610,7 +4610,7 @@ The date on which the relationship became no longer applicable.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>ended</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.ended">ended</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
 
@@ -4619,7 +4619,7 @@ Whether the relationship still applies.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>attributes</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.attributes">attributes</strong></td>
 <td valign="top">[<a href="#string">String</a>]</td>
 <td>
 
@@ -4631,7 +4631,7 @@ relationship type.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -4640,7 +4640,7 @@ The type of relationship.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -4667,7 +4667,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="relationshipconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -4676,7 +4676,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="relationshipconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#relationshipedge">RelationshipEdge</a>]</td>
 <td>
 
@@ -4685,7 +4685,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="relationshipconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#relationship">Relationship</a>]</td>
 <td>
 
@@ -4695,7 +4695,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="relationshipconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -4722,7 +4722,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="relationshipedge.node">node</strong></td>
 <td valign="top"><a href="#relationship">Relationship</a></td>
 <td>
 
@@ -4731,7 +4731,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="relationshipedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -4740,7 +4740,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="relationshipedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -4767,7 +4767,7 @@ Lists of entity relationships for each entity type.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>areas</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.areas">areas</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -4824,7 +4824,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.artists">artists</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -4881,7 +4881,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>events</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.events">events</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -4938,7 +4938,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>instruments</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.instruments">instruments</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -4995,7 +4995,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>labels</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.labels">labels</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -5052,7 +5052,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>places</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.places">places</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -5109,7 +5109,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>recordings</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.recordings">recordings</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -5166,7 +5166,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.releases">releases</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -5223,7 +5223,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releaseGroups</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.releasegroups">releaseGroups</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -5280,7 +5280,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>series</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.series">series</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -5337,7 +5337,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>urls</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.urls">urls</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -5394,7 +5394,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>works</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.works">works</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -5472,7 +5472,7 @@ MusicBrainz as one release.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="release.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -5481,7 +5481,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="release.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -5490,7 +5490,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>title</strong></td>
+<td colspan="2" valign="top"><strong id="release.title">title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -5499,7 +5499,7 @@ The official title of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="release.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -5508,7 +5508,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="release.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -5518,7 +5518,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artistCredit</strong> ⚠️</td>
+<td colspan="2" valign="top"><strong id="release.artistcredit">artistCredit</strong> ⚠️</td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
 
@@ -5537,7 +5537,7 @@ and will be removed in a major release in the future. Use the equivalent
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artistCredits</strong></td>
+<td colspan="2" valign="top"><strong id="release.artistcredits">artistCredits</strong></td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
 
@@ -5546,7 +5546,7 @@ The main credited artist(s).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releaseEvents</strong></td>
+<td colspan="2" valign="top"><strong id="release.releaseevents">releaseEvents</strong></td>
 <td valign="top">[<a href="#releaseevent">ReleaseEvent</a>]</td>
 <td>
 
@@ -5555,7 +5555,7 @@ The release events for this release.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>date</strong></td>
+<td colspan="2" valign="top"><strong id="release.date">date</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
 
@@ -5566,7 +5566,7 @@ distribution mechanism.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>country</strong></td>
+<td colspan="2" valign="top"><strong id="release.country">country</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -5575,7 +5575,7 @@ The country in which the release was issued.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>asin</strong></td>
+<td colspan="2" valign="top"><strong id="release.asin">asin</strong></td>
 <td valign="top"><a href="#asin">ASIN</a></td>
 <td>
 
@@ -5585,7 +5585,7 @@ of the release.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>barcode</strong></td>
+<td colspan="2" valign="top"><strong id="release.barcode">barcode</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -5597,7 +5597,7 @@ release has one. The most common types found on releases are 12-digit
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>status</strong></td>
+<td colspan="2" valign="top"><strong id="release.status">status</strong></td>
 <td valign="top"><a href="#releasestatus">ReleaseStatus</a></td>
 <td>
 
@@ -5606,7 +5606,7 @@ The status describes how “official” a release is.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>statusID</strong></td>
+<td colspan="2" valign="top"><strong id="release.statusid">statusID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -5616,7 +5616,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>packaging</strong></td>
+<td colspan="2" valign="top"><strong id="release.packaging">packaging</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -5627,7 +5627,7 @@ information.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>packagingID</strong></td>
+<td colspan="2" valign="top"><strong id="release.packagingid">packagingID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -5637,7 +5637,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>quality</strong></td>
+<td colspan="2" valign="top"><strong id="release.quality">quality</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -5648,7 +5648,7 @@ It is not a mark of how good or bad the music itself is – for that, use
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>media</strong></td>
+<td colspan="2" valign="top"><strong id="release.media">media</strong></td>
 <td valign="top">[<a href="#medium">Medium</a>]</td>
 <td>
 
@@ -5657,7 +5657,7 @@ The media on which the release was distributed.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="release.artists">artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
 
@@ -5676,7 +5676,7 @@ A list of artists linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>labels</strong></td>
+<td colspan="2" valign="top"><strong id="release.labels">labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
 
@@ -5695,7 +5695,7 @@ A list of labels linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>recordings</strong></td>
+<td colspan="2" valign="top"><strong id="release.recordings">recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
 
@@ -5714,7 +5714,7 @@ A list of recordings linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releaseGroups</strong></td>
+<td colspan="2" valign="top"><strong id="release.releasegroups">releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
 
@@ -5742,7 +5742,7 @@ Filter by one or more release group types.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="release.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -5751,7 +5751,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="release.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -5770,7 +5770,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="release.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -5789,7 +5789,7 @@ A list of tags linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>coverArtArchive</strong></td>
+<td colspan="2" valign="top"><strong id="release.coverartarchive">coverArtArchive</strong></td>
 <td valign="top"><a href="#coverartarchiverelease">CoverArtArchiveRelease</a></td>
 <td>
 
@@ -5817,7 +5817,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="releaseconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -5826,7 +5826,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="releaseconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#releaseedge">ReleaseEdge</a>]</td>
 <td>
 
@@ -5835,7 +5835,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="releaseconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#release">Release</a>]</td>
 <td>
 
@@ -5845,7 +5845,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="releaseconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -5872,7 +5872,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="releaseedge.node">node</strong></td>
 <td valign="top"><a href="#release">Release</a></td>
 <td>
 
@@ -5881,7 +5881,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="releaseedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -5890,7 +5890,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="releaseedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -5918,12 +5918,12 @@ a particular label, catalog number, barcode, and format.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>area</strong></td>
+<td colspan="2" valign="top"><strong id="releaseevent.area">area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>date</strong></td>
+<td colspan="2" valign="top"><strong id="releaseevent.date">date</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td></td>
 </tr>
@@ -5952,7 +5952,7 @@ album – it doesn’t matter how many CDs or editions/versions it had.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -5961,7 +5961,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -5970,7 +5970,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>title</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.title">title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -5979,7 +5979,7 @@ The official title of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -5988,7 +5988,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -5998,7 +5998,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artistCredit</strong> ⚠️</td>
+<td colspan="2" valign="top"><strong id="releasegroup.artistcredit">artistCredit</strong> ⚠️</td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
 
@@ -6017,7 +6017,7 @@ and will be removed in a major release in the future. Use the equivalent
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artistCredits</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.artistcredits">artistCredits</strong></td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
 
@@ -6026,7 +6026,7 @@ The main credited artist(s).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>firstReleaseDate</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.firstreleasedate">firstReleaseDate</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
 
@@ -6035,7 +6035,7 @@ The date of the earliest release in the group.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>primaryType</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.primarytype">primaryType</strong></td>
 <td valign="top"><a href="#releasegrouptype">ReleaseGroupType</a></td>
 <td>
 
@@ -6047,7 +6047,7 @@ e.g. album, single, soundtrack, compilation, etc. A release group can have a
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>primaryTypeID</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.primarytypeid">primaryTypeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -6057,7 +6057,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>secondaryTypes</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.secondarytypes">secondaryTypes</strong></td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
 
@@ -6067,7 +6067,7 @@ that apply to this release group.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>secondaryTypeIDs</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.secondarytypeids">secondaryTypeIDs</strong></td>
 <td valign="top">[<a href="#mbid">MBID</a>]</td>
 <td>
 
@@ -6077,7 +6077,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.artists">artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
 
@@ -6096,7 +6096,7 @@ A list of artists linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -6133,7 +6133,7 @@ Filter by one or more release statuses.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -6142,7 +6142,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -6161,7 +6161,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>rating</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.rating">rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
 
@@ -6170,7 +6170,7 @@ The rating users have given to this entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -6189,7 +6189,7 @@ A list of tags linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>coverArtArchive</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.coverartarchive">coverArtArchive</strong></td>
 <td valign="top"><a href="#coverartarchiverelease">CoverArtArchiveRelease</a></td>
 <td>
 
@@ -6219,7 +6219,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroupconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -6228,7 +6228,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroupconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#releasegroupedge">ReleaseGroupEdge</a>]</td>
 <td>
 
@@ -6237,7 +6237,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroupconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#releasegroup">ReleaseGroup</a>]</td>
 <td>
 
@@ -6247,7 +6247,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroupconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -6274,7 +6274,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroupedge.node">node</strong></td>
 <td valign="top"><a href="#releasegroup">ReleaseGroup</a></td>
 <td>
 
@@ -6283,7 +6283,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroupedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -6292,7 +6292,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroupedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -6319,7 +6319,7 @@ A search for MusicBrainz entities using Lucene query syntax.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>areas</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.areas">areas</strong></td>
 <td valign="top"><a href="#areaconnection">AreaConnection</a></td>
 <td>
 
@@ -6348,7 +6348,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.artists">artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
 
@@ -6377,7 +6377,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>events</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.events">events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
 
@@ -6406,7 +6406,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>instruments</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.instruments">instruments</strong></td>
 <td valign="top"><a href="#instrumentconnection">InstrumentConnection</a></td>
 <td>
 
@@ -6435,7 +6435,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>labels</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.labels">labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
 
@@ -6464,7 +6464,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>places</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.places">places</strong></td>
 <td valign="top"><a href="#placeconnection">PlaceConnection</a></td>
 <td>
 
@@ -6493,7 +6493,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>recordings</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.recordings">recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
 
@@ -6522,7 +6522,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -6551,7 +6551,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releaseGroups</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.releasegroups">releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
 
@@ -6580,7 +6580,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>series</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.series">series</strong></td>
 <td valign="top"><a href="#seriesconnection">SeriesConnection</a></td>
 <td>
 
@@ -6609,7 +6609,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>works</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.works">works</strong></td>
 <td valign="top"><a href="#workconnection">WorkConnection</a></td>
 <td>
 
@@ -6657,7 +6657,7 @@ theme.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="series.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -6666,7 +6666,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="series.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -6675,7 +6675,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="series.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -6684,7 +6684,7 @@ The official name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="series.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -6693,7 +6693,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="series.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -6703,7 +6703,7 @@ contains.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="series.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -6713,7 +6713,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="series.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -6722,7 +6722,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="series.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -6741,7 +6741,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="series.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -6777,7 +6777,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="seriesconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -6786,7 +6786,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="seriesconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#seriesedge">SeriesEdge</a>]</td>
 <td>
 
@@ -6795,7 +6795,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="seriesconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#series">Series</a>]</td>
 <td>
 
@@ -6805,7 +6805,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="seriesconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -6832,7 +6832,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="seriesedge.node">node</strong></td>
 <td valign="top"><a href="#series">Series</a></td>
 <td>
 
@@ -6841,7 +6841,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="seriesedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -6850,7 +6850,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="seriesedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -6879,7 +6879,7 @@ release, or recording.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="tag.name">name</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -6888,7 +6888,7 @@ The tag label.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>count</strong></td>
+<td colspan="2" valign="top"><strong id="tag.count">count</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -6914,7 +6914,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="tagconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -6923,7 +6923,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="tagconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#tagedge">TagEdge</a>]</td>
 <td>
 
@@ -6932,7 +6932,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="tagconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#tag">Tag</a>]</td>
 <td>
 
@@ -6942,7 +6942,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="tagconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -6969,7 +6969,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="tagedge.node">node</strong></td>
 <td valign="top"><a href="#tag">Tag</a></td>
 <td>
 
@@ -6978,7 +6978,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="tagedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -6987,7 +6987,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="tagedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -7016,7 +7016,7 @@ A track is the way a recording is represented on a particular
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="track.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -7025,7 +7025,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>title</strong></td>
+<td colspan="2" valign="top"><strong id="track.title">title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -7034,7 +7034,7 @@ The official title of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>position</strong></td>
+<td colspan="2" valign="top"><strong id="track.position">position</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -7044,7 +7044,7 @@ tracks from all discs).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>number</strong></td>
+<td colspan="2" valign="top"><strong id="track.number">number</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -7054,7 +7054,7 @@ disc or side it appears on, e.g. “A1” or “B3”.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>length</strong></td>
+<td colspan="2" valign="top"><strong id="track.length">length</strong></td>
 <td valign="top"><a href="#duration">Duration</a></td>
 <td>
 
@@ -7063,7 +7063,7 @@ The length of the track.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>recording</strong></td>
+<td colspan="2" valign="top"><strong id="track.recording">recording</strong></td>
 <td valign="top"><a href="#recording">Recording</a></td>
 <td>
 
@@ -7091,7 +7091,7 @@ acquired, an entry in another database, etc.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="url.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -7100,7 +7100,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="url.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -7109,7 +7109,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>resource</strong></td>
+<td colspan="2" valign="top"><strong id="url.resource">resource</strong></td>
 <td valign="top"><a href="#urlstring">URLString</a>!</td>
 <td>
 
@@ -7118,7 +7118,7 @@ The actual URL string.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="url.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -7146,7 +7146,7 @@ more audio recordings.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="work.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -7155,7 +7155,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="work.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -7164,7 +7164,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>title</strong></td>
+<td colspan="2" valign="top"><strong id="work.title">title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -7173,7 +7173,7 @@ The official title of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="work.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -7182,7 +7182,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="work.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -7192,7 +7192,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>iswcs</strong></td>
+<td colspan="2" valign="top"><strong id="work.iswcs">iswcs</strong></td>
 <td valign="top">[<a href="#string">String</a>]</td>
 <td>
 
@@ -7202,7 +7202,7 @@ to the work by copyright collecting agencies.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>language</strong></td>
+<td colspan="2" valign="top"><strong id="work.language">language</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -7211,7 +7211,7 @@ The language in which the work was originally written.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="work.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -7220,7 +7220,7 @@ The type of work.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="work.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -7230,7 +7230,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="work.artists">artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
 
@@ -7249,7 +7249,7 @@ A list of artists linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="work.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -7258,7 +7258,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="work.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -7277,7 +7277,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>rating</strong></td>
+<td colspan="2" valign="top"><strong id="work.rating">rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
 
@@ -7286,7 +7286,7 @@ The rating users have given to this entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="work.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -7322,7 +7322,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="workconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -7331,7 +7331,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="workconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#workedge">WorkEdge</a>]</td>
 <td>
 
@@ -7340,7 +7340,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="workconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#work">Work</a>]</td>
 <td>
 
@@ -7350,7 +7350,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="workconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -7377,7 +7377,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="workedge.node">node</strong></td>
 <td valign="top"><a href="#work">Work</a></td>
 <td>
 
@@ -7386,7 +7386,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="workedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -7395,7 +7395,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="workedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -7799,7 +7799,7 @@ An entity in the MusicBrainz schema.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="entity.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -7825,7 +7825,7 @@ An object with an ID
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="node.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 

--- a/test/fixtures/graphbrainz.md
+++ b/test/fixtures/graphbrainz.md
@@ -105,7 +105,7 @@ requests can be made.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>lookup</strong></td>
+<td colspan="2" valign="top"><strong id="query.lookup">lookup</strong></td>
 <td valign="top"><a href="#lookupquery">LookupQuery</a></td>
 <td>
 
@@ -114,7 +114,7 @@ Perform a lookup of a MusicBrainz entity by its MBID.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>browse</strong></td>
+<td colspan="2" valign="top"><strong id="query.browse">browse</strong></td>
 <td valign="top"><a href="#browsequery">BrowseQuery</a></td>
 <td>
 
@@ -123,7 +123,7 @@ Browse all MusicBrainz entities directly linked to another entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>search</strong></td>
+<td colspan="2" valign="top"><strong id="query.search">search</strong></td>
 <td valign="top"><a href="#searchquery">SearchQuery</a></td>
 <td>
 
@@ -132,7 +132,7 @@ Search for MusicBrainz entities using Lucene query syntax.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="query.node">node</strong></td>
 <td valign="top"><a href="#node">Node</a></td>
 <td>
 
@@ -171,7 +171,7 @@ entity will be given as a result – even if the actual name wouldn’t be.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="alias.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -180,7 +180,7 @@ The aliased name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>sortName</strong></td>
+<td colspan="2" valign="top"><strong id="alias.sortname">sortName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -191,7 +191,7 @@ the front).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>locale</strong></td>
+<td colspan="2" valign="top"><strong id="alias.locale">locale</strong></td>
 <td valign="top"><a href="#locale">Locale</a></td>
 <td>
 
@@ -201,7 +201,7 @@ used.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>primary</strong></td>
+<td colspan="2" valign="top"><strong id="alias.primary">primary</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
 
@@ -211,7 +211,7 @@ specified locale (this could mean the most recent or the most common).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="alias.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -221,7 +221,7 @@ search hint, etc.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="alias.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -249,7 +249,7 @@ or settlements (countries, cities, or the like).
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="area.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -258,7 +258,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="area.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -267,7 +267,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="area.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -276,7 +276,7 @@ The official name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>sortName</strong></td>
+<td colspan="2" valign="top"><strong id="area.sortname">sortName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -287,7 +287,7 @@ the front).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="area.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -296,7 +296,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="area.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -306,7 +306,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>isoCodes</strong></td>
+<td colspan="2" valign="top"><strong id="area.isocodes">isoCodes</strong></td>
 <td valign="top">[<a href="#string">String</a>]</td>
 <td>
 
@@ -326,7 +326,7 @@ Available ISO standards are 3166-1, 3166-2, and 3166-3.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="area.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -336,7 +336,7 @@ values](https://musicbrainz.org/doc/Area)).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="area.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -346,7 +346,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="area.artists">artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
 
@@ -365,7 +365,7 @@ A list of artists linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>events</strong></td>
+<td colspan="2" valign="top"><strong id="area.events">events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
 
@@ -384,7 +384,7 @@ A list of events linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>labels</strong></td>
+<td colspan="2" valign="top"><strong id="area.labels">labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
 
@@ -403,7 +403,7 @@ A list of labels linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>places</strong></td>
+<td colspan="2" valign="top"><strong id="area.places">places</strong></td>
 <td valign="top"><a href="#placeconnection">PlaceConnection</a></td>
 <td>
 
@@ -422,7 +422,7 @@ A list of places linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="area.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -459,7 +459,7 @@ Filter by one or more release statuses.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="area.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -468,7 +468,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="area.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -487,7 +487,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="area.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -523,7 +523,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="areaconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -532,7 +532,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="areaconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#areaedge">AreaEdge</a>]</td>
 <td>
 
@@ -541,7 +541,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="areaconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#area">Area</a>]</td>
 <td>
 
@@ -551,7 +551,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="areaconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -578,7 +578,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="areaedge.node">node</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
 
@@ -587,7 +587,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="areaedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -596,7 +596,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="areaedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -627,7 +627,7 @@ even a fictional character.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="artist.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -636,7 +636,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="artist.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -645,7 +645,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="artist.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -654,7 +654,7 @@ The official name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>sortName</strong></td>
+<td colspan="2" valign="top"><strong id="artist.sortname">sortName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -665,7 +665,7 @@ the front).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="artist.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -674,7 +674,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="artist.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -684,7 +684,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>country</strong></td>
+<td colspan="2" valign="top"><strong id="artist.country">country</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -694,7 +694,7 @@ is often, but not always, its birth/formation country.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>area</strong></td>
+<td colspan="2" valign="top"><strong id="artist.area">area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
 
@@ -704,7 +704,7 @@ is often, but not always, its birth/formation country.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>beginArea</strong></td>
+<td colspan="2" valign="top"><strong id="artist.beginarea">beginArea</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
 
@@ -714,7 +714,7 @@ they were born, if the artist is a person).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>endArea</strong></td>
+<td colspan="2" valign="top"><strong id="artist.endarea">endArea</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
 
@@ -724,7 +724,7 @@ they died, if the artist is a person).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>lifeSpan</strong></td>
+<td colspan="2" valign="top"><strong id="artist.lifespan">lifeSpan</strong></td>
 <td valign="top"><a href="#lifespan">LifeSpan</a></td>
 <td>
 
@@ -734,7 +734,7 @@ meaning depends on the type of entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>gender</strong></td>
+<td colspan="2" valign="top"><strong id="artist.gender">gender</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -744,7 +744,7 @@ neither. Groups do not have genders.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>genderID</strong></td>
+<td colspan="2" valign="top"><strong id="artist.genderid">genderID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -754,7 +754,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="artist.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -763,7 +763,7 @@ Whether an artist is a person, a group, or something else.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="artist.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -773,7 +773,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>ipis</strong></td>
+<td colspan="2" valign="top"><strong id="artist.ipis">ipis</strong></td>
 <td valign="top">[<a href="#ipi">IPI</a>]</td>
 <td>
 
@@ -783,7 +783,7 @@ List of [Interested Parties Information](https://musicbrainz.org/doc/IPI)
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>isnis</strong></td>
+<td colspan="2" valign="top"><strong id="artist.isnis">isnis</strong></td>
 <td valign="top">[<a href="#isni">ISNI</a>]</td>
 <td>
 
@@ -793,7 +793,7 @@ List of [International Standard Name Identifier](https://musicbrainz.org/doc/ISN
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>recordings</strong></td>
+<td colspan="2" valign="top"><strong id="artist.recordings">recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
 
@@ -812,7 +812,7 @@ A list of recordings linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="artist.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -849,7 +849,7 @@ Filter by one or more release statuses.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releaseGroups</strong></td>
+<td colspan="2" valign="top"><strong id="artist.releasegroups">releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
 
@@ -877,7 +877,7 @@ Filter by one or more release group types.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>works</strong></td>
+<td colspan="2" valign="top"><strong id="artist.works">works</strong></td>
 <td valign="top"><a href="#workconnection">WorkConnection</a></td>
 <td>
 
@@ -896,7 +896,7 @@ A list of works linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="artist.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -905,7 +905,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="artist.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -924,7 +924,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>rating</strong></td>
+<td colspan="2" valign="top"><strong id="artist.rating">rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
 
@@ -933,7 +933,7 @@ The rating users have given to this entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="artist.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -969,7 +969,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="artistconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -978,7 +978,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="artistconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#artistedge">ArtistEdge</a>]</td>
 <td>
 
@@ -987,7 +987,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="artistconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#artist">Artist</a>]</td>
 <td>
 
@@ -997,7 +997,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="artistconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -1028,7 +1028,7 @@ track, etc., and join phrases between them.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>artist</strong></td>
+<td colspan="2" valign="top"><strong id="artistcredit.artist">artist</strong></td>
 <td valign="top"><a href="#artist">Artist</a></td>
 <td>
 
@@ -1038,7 +1038,7 @@ credits.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="artistcredit.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -1048,7 +1048,7 @@ track, etc.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>joinPhrase</strong></td>
+<td colspan="2" valign="top"><strong id="artistcredit.joinphrase">joinPhrase</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -1075,7 +1075,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="artistedge.node">node</strong></td>
 <td valign="top"><a href="#artist">Artist</a></td>
 <td>
 
@@ -1084,7 +1084,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="artistedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -1093,7 +1093,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="artistedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -1121,7 +1121,7 @@ entity.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>areas</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.areas">areas</strong></td>
 <td valign="top"><a href="#areaconnection">AreaConnection</a></td>
 <td>
 
@@ -1149,7 +1149,7 @@ The MBID of a collection in which the entity is found.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.artists">artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
 
@@ -1222,7 +1222,7 @@ The MBID of a work to which the entity is linked.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -1331,7 +1331,7 @@ The MBID of a work to which the entity is linked.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>events</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.events">events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
 
@@ -1386,7 +1386,7 @@ The MBID of a place to which the entity is linked.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>labels</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.labels">labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
 
@@ -1432,7 +1432,7 @@ The MBID of a release to which the entity is linked.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>places</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.places">places</strong></td>
 <td valign="top"><a href="#placeconnection">PlaceConnection</a></td>
 <td>
 
@@ -1469,7 +1469,7 @@ The MBID of a collection in which the entity is found.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>recordings</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.recordings">recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
 
@@ -1525,7 +1525,7 @@ The MBID of a release to which the entity is linked.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -1645,7 +1645,7 @@ Filter by one or more release statuses.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releaseGroups</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.releasegroups">releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
 
@@ -1700,7 +1700,7 @@ Filter by one or more release group types.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>works</strong></td>
+<td colspan="2" valign="top"><strong id="browsequery.works">works</strong></td>
 <td valign="top"><a href="#workconnection">WorkConnection</a></td>
 <td>
 
@@ -1765,7 +1765,7 @@ lists of entities that users can create.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="collection.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -1774,7 +1774,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="collection.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -1783,7 +1783,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="collection.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -1792,7 +1792,7 @@ The official name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>editor</strong></td>
+<td colspan="2" valign="top"><strong id="collection.editor">editor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -1801,7 +1801,7 @@ The username of the editor who created the collection.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>entityType</strong></td>
+<td colspan="2" valign="top"><strong id="collection.entitytype">entityType</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -1810,7 +1810,7 @@ The type of entity listed in the collection.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="collection.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -1819,7 +1819,7 @@ The type of collection.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="collection.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -1829,7 +1829,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>areas</strong></td>
+<td colspan="2" valign="top"><strong id="collection.areas">areas</strong></td>
 <td valign="top"><a href="#areaconnection">AreaConnection</a></td>
 <td>
 
@@ -1848,7 +1848,7 @@ The list of areas found in this collection.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="collection.artists">artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
 
@@ -1867,7 +1867,7 @@ The list of artists found in this collection.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>events</strong></td>
+<td colspan="2" valign="top"><strong id="collection.events">events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
 
@@ -1886,7 +1886,7 @@ The list of events found in this collection.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>instruments</strong></td>
+<td colspan="2" valign="top"><strong id="collection.instruments">instruments</strong></td>
 <td valign="top"><a href="#instrumentconnection">InstrumentConnection</a></td>
 <td>
 
@@ -1905,7 +1905,7 @@ The list of instruments found in this collection.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>labels</strong></td>
+<td colspan="2" valign="top"><strong id="collection.labels">labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
 
@@ -1924,7 +1924,7 @@ The list of labels found in this collection.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>places</strong></td>
+<td colspan="2" valign="top"><strong id="collection.places">places</strong></td>
 <td valign="top"><a href="#placeconnection">PlaceConnection</a></td>
 <td>
 
@@ -1943,7 +1943,7 @@ The list of places found in this collection.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>recordings</strong></td>
+<td colspan="2" valign="top"><strong id="collection.recordings">recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
 
@@ -1962,7 +1962,7 @@ The list of recordings found in this collection.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="collection.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -1999,7 +1999,7 @@ Filter by one or more release statuses.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releaseGroups</strong></td>
+<td colspan="2" valign="top"><strong id="collection.releasegroups">releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
 
@@ -2027,7 +2027,7 @@ Filter by one or more release group types.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>series</strong></td>
+<td colspan="2" valign="top"><strong id="collection.series">series</strong></td>
 <td valign="top"><a href="#seriesconnection">SeriesConnection</a></td>
 <td>
 
@@ -2046,7 +2046,7 @@ The list of series found in this collection.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>works</strong></td>
+<td colspan="2" valign="top"><strong id="collection.works">works</strong></td>
 <td valign="top"><a href="#workconnection">WorkConnection</a></td>
 <td>
 
@@ -2082,7 +2082,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="collectionconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -2091,7 +2091,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="collectionconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#collectionedge">CollectionEdge</a>]</td>
 <td>
 
@@ -2100,7 +2100,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="collectionconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#collection">Collection</a>]</td>
 <td>
 
@@ -2110,7 +2110,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="collectionconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -2137,7 +2137,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="collectionedge.node">node</strong></td>
 <td valign="top"><a href="#collection">Collection</a></td>
 <td>
 
@@ -2146,7 +2146,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="collectionedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -2155,7 +2155,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="collectionedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -2182,7 +2182,7 @@ Geographic coordinates described with latitude and longitude.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>latitude</strong></td>
+<td colspan="2" valign="top"><strong id="coordinates.latitude">latitude</strong></td>
 <td valign="top"><a href="#degrees">Degrees</a></td>
 <td>
 
@@ -2191,7 +2191,7 @@ The north–south position of a point on the Earth’s surface.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>longitude</strong></td>
+<td colspan="2" valign="top"><strong id="coordinates.longitude">longitude</strong></td>
 <td valign="top"><a href="#degrees">Degrees</a></td>
 <td>
 
@@ -2218,7 +2218,7 @@ particular [disc ID](https://musicbrainz.org/doc/Disc_ID).
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="disc.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -2227,7 +2227,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>discID</strong></td>
+<td colspan="2" valign="top"><strong id="disc.discid">discID</strong></td>
 <td valign="top"><a href="#discid">DiscID</a>!</td>
 <td>
 
@@ -2236,7 +2236,7 @@ The [disc ID](https://musicbrainz.org/doc/Disc_ID) of this disc.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>offsetCount</strong></td>
+<td colspan="2" valign="top"><strong id="disc.offsetcount">offsetCount</strong></td>
 <td valign="top"><a href="#int">Int</a>!</td>
 <td>
 
@@ -2245,7 +2245,7 @@ The number of offsets (tracks) on the disc.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>offsets</strong></td>
+<td colspan="2" valign="top"><strong id="disc.offsets">offsets</strong></td>
 <td valign="top">[<a href="#int">Int</a>]</td>
 <td>
 
@@ -2254,7 +2254,7 @@ The sector offset of each track on the disc.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>sectors</strong></td>
+<td colspan="2" valign="top"><strong id="disc.sectors">sectors</strong></td>
 <td valign="top"><a href="#int">Int</a>!</td>
 <td>
 
@@ -2263,7 +2263,7 @@ The sector offset of the lead-out (the end of the disc).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="disc.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -2301,7 +2301,7 @@ Generally this means live performances, like concerts and festivals.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="event.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -2310,7 +2310,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="event.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -2319,7 +2319,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="event.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2328,7 +2328,7 @@ The official name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="event.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2337,7 +2337,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="event.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -2347,7 +2347,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>lifeSpan</strong></td>
+<td colspan="2" valign="top"><strong id="event.lifespan">lifeSpan</strong></td>
 <td valign="top"><a href="#lifespan">LifeSpan</a></td>
 <td>
 
@@ -2357,7 +2357,7 @@ meaning depends on the type of entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>time</strong></td>
+<td colspan="2" valign="top"><strong id="event.time">time</strong></td>
 <td valign="top"><a href="#time">Time</a></td>
 <td>
 
@@ -2366,7 +2366,7 @@ The start time of the event.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cancelled</strong></td>
+<td colspan="2" valign="top"><strong id="event.cancelled">cancelled</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
 
@@ -2375,7 +2375,7 @@ Whether or not the event took place.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>setlist</strong></td>
+<td colspan="2" valign="top"><strong id="event.setlist">setlist</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2386,7 +2386,7 @@ for syntax and examples.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="event.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2395,7 +2395,7 @@ What kind of event the event is, e.g. concert, festival, etc.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="event.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -2405,7 +2405,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="event.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -2414,7 +2414,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="event.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -2433,7 +2433,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>rating</strong></td>
+<td colspan="2" valign="top"><strong id="event.rating">rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
 
@@ -2442,7 +2442,7 @@ The rating users have given to this entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="event.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -2478,7 +2478,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="eventconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -2487,7 +2487,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="eventconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#eventedge">EventEdge</a>]</td>
 <td>
 
@@ -2496,7 +2496,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="eventconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#event">Event</a>]</td>
 <td>
 
@@ -2506,7 +2506,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="eventconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -2533,7 +2533,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="eventedge.node">node</strong></td>
 <td valign="top"><a href="#event">Event</a></td>
 <td>
 
@@ -2542,7 +2542,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="eventedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -2551,7 +2551,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="eventedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -2580,7 +2580,7 @@ used in relationships between two other entities.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -2589,7 +2589,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -2598,7 +2598,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2607,7 +2607,7 @@ The official name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2616,7 +2616,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -2626,7 +2626,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>description</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.description">description</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2636,7 +2636,7 @@ instrument.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2647,7 +2647,7 @@ classification.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -2657,7 +2657,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -2666,7 +2666,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -2685,7 +2685,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="instrument.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -2721,7 +2721,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="instrumentconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -2730,7 +2730,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="instrumentconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#instrumentedge">InstrumentEdge</a>]</td>
 <td>
 
@@ -2739,7 +2739,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="instrumentconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#instrument">Instrument</a>]</td>
 <td>
 
@@ -2749,7 +2749,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="instrumentconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -2776,7 +2776,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="instrumentedge.node">node</strong></td>
 <td valign="top"><a href="#instrument">Instrument</a></td>
 <td>
 
@@ -2785,7 +2785,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="instrumentedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -2794,7 +2794,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="instrumentedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -2823,7 +2823,7 @@ represent a record company.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="label.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -2832,7 +2832,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="label.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -2841,7 +2841,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="label.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2850,7 +2850,7 @@ The official name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>sortName</strong></td>
+<td colspan="2" valign="top"><strong id="label.sortname">sortName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2861,7 +2861,7 @@ the front).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="label.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2870,7 +2870,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="label.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -2880,7 +2880,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>country</strong></td>
+<td colspan="2" valign="top"><strong id="label.country">country</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2889,7 +2889,7 @@ The country of origin for the label.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>area</strong></td>
+<td colspan="2" valign="top"><strong id="label.area">area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
 
@@ -2898,7 +2898,7 @@ The area in which the label is based.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>lifeSpan</strong></td>
+<td colspan="2" valign="top"><strong id="label.lifespan">lifeSpan</strong></td>
 <td valign="top"><a href="#lifespan">LifeSpan</a></td>
 <td>
 
@@ -2908,7 +2908,7 @@ meaning depends on the type of entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>labelCode</strong></td>
+<td colspan="2" valign="top"><strong id="label.labelcode">labelCode</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -2918,7 +2918,7 @@ of the label.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>ipis</strong></td>
+<td colspan="2" valign="top"><strong id="label.ipis">ipis</strong></td>
 <td valign="top">[<a href="#ipi">IPI</a>]</td>
 <td>
 
@@ -2928,7 +2928,7 @@ codes for the label.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="label.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -2938,7 +2938,7 @@ imprint, production, distributor, rights society, etc.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="label.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -2948,7 +2948,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="label.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -2985,7 +2985,7 @@ Filter by one or more release statuses.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="label.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -2994,7 +2994,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="label.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -3013,7 +3013,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>rating</strong></td>
+<td colspan="2" valign="top"><strong id="label.rating">rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
 
@@ -3022,7 +3022,7 @@ The rating users have given to this entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="label.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -3058,7 +3058,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="labelconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -3067,7 +3067,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="labelconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#labeledge">LabelEdge</a>]</td>
 <td>
 
@@ -3076,7 +3076,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="labelconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#label">Label</a>]</td>
 <td>
 
@@ -3086,7 +3086,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="labelconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -3113,7 +3113,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="labeledge.node">node</strong></td>
 <td valign="top"><a href="#label">Label</a></td>
 <td>
 
@@ -3122,7 +3122,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="labeledge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -3131,7 +3131,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="labeledge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -3159,7 +3159,7 @@ lifetime, including whether it has ended (even if the date is unknown).
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>begin</strong></td>
+<td colspan="2" valign="top"><strong id="lifespan.begin">begin</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
 
@@ -3168,7 +3168,7 @@ The start date of the entity’s life span.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>end</strong></td>
+<td colspan="2" valign="top"><strong id="lifespan.end">end</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
 
@@ -3177,7 +3177,7 @@ The end date of the entity’s life span.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>ended</strong></td>
+<td colspan="2" valign="top"><strong id="lifespan.ended">ended</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
 
@@ -3203,7 +3203,7 @@ A lookup of an individual MusicBrainz entity by its MBID.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>area</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.area">area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
 
@@ -3221,7 +3221,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artist</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.artist">artist</strong></td>
 <td valign="top"><a href="#artist">Artist</a></td>
 <td>
 
@@ -3239,7 +3239,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collection</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.collection">collection</strong></td>
 <td valign="top"><a href="#collection">Collection</a></td>
 <td>
 
@@ -3257,7 +3257,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disc</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.disc">disc</strong></td>
 <td valign="top"><a href="#disc">Disc</a></td>
 <td>
 
@@ -3276,7 +3276,7 @@ of the disc.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>event</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.event">event</strong></td>
 <td valign="top"><a href="#event">Event</a></td>
 <td>
 
@@ -3294,7 +3294,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>instrument</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.instrument">instrument</strong></td>
 <td valign="top"><a href="#instrument">Instrument</a></td>
 <td>
 
@@ -3312,7 +3312,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>label</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.label">label</strong></td>
 <td valign="top"><a href="#label">Label</a></td>
 <td>
 
@@ -3330,7 +3330,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>place</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.place">place</strong></td>
 <td valign="top"><a href="#place">Place</a></td>
 <td>
 
@@ -3348,7 +3348,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>recording</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.recording">recording</strong></td>
 <td valign="top"><a href="#recording">Recording</a></td>
 <td>
 
@@ -3366,7 +3366,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>release</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.release">release</strong></td>
 <td valign="top"><a href="#release">Release</a></td>
 <td>
 
@@ -3384,7 +3384,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releaseGroup</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.releasegroup">releaseGroup</strong></td>
 <td valign="top"><a href="#releasegroup">ReleaseGroup</a></td>
 <td>
 
@@ -3402,7 +3402,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>series</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.series">series</strong></td>
 <td valign="top"><a href="#series">Series</a></td>
 <td>
 
@@ -3420,7 +3420,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>url</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.url">url</strong></td>
 <td valign="top"><a href="#url">URL</a></td>
 <td>
 
@@ -3447,7 +3447,7 @@ The web address of the URL entity to look up.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>work</strong></td>
+<td colspan="2" valign="top"><strong id="lookupquery.work">work</strong></td>
 <td valign="top"><a href="#work">Work</a></td>
 <td>
 
@@ -3486,7 +3486,7 @@ cassette) and can optionally also have a title.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>title</strong></td>
+<td colspan="2" valign="top"><strong id="medium.title">title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3495,7 +3495,7 @@ The title of this particular medium.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>format</strong></td>
+<td colspan="2" valign="top"><strong id="medium.format">format</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3505,7 +3505,7 @@ the medium (e.g. CD, DVD, vinyl, cassette).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>formatID</strong></td>
+<td colspan="2" valign="top"><strong id="medium.formatid">formatID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -3515,7 +3515,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>position</strong></td>
+<td colspan="2" valign="top"><strong id="medium.position">position</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -3525,7 +3525,7 @@ multi-disc release).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>trackCount</strong></td>
+<td colspan="2" valign="top"><strong id="medium.trackcount">trackCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -3534,7 +3534,7 @@ The number of audio tracks on this medium.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>discs</strong></td>
+<td colspan="2" valign="top"><strong id="medium.discs">discs</strong></td>
 <td valign="top">[<a href="#disc">Disc</a>]</td>
 <td>
 
@@ -3543,7 +3543,7 @@ A list of physical discs and their disc IDs for this medium.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tracks</strong></td>
+<td colspan="2" valign="top"><strong id="medium.tracks">tracks</strong></td>
 <td valign="top">[<a href="#track">Track</a>]</td>
 <td>
 
@@ -3569,7 +3569,7 @@ Information about pagination in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>hasNextPage</strong></td>
+<td colspan="2" valign="top"><strong id="pageinfo.hasnextpage">hasNextPage</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a>!</td>
 <td>
 
@@ -3578,7 +3578,7 @@ When paginating forwards, are there more items?
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>hasPreviousPage</strong></td>
+<td colspan="2" valign="top"><strong id="pageinfo.haspreviouspage">hasPreviousPage</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a>!</td>
 <td>
 
@@ -3587,7 +3587,7 @@ When paginating backwards, are there more items?
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>startCursor</strong></td>
+<td colspan="2" valign="top"><strong id="pageinfo.startcursor">startCursor</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3596,7 +3596,7 @@ When paginating backwards, the cursor to continue.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>endCursor</strong></td>
+<td colspan="2" valign="top"><strong id="pageinfo.endcursor">endCursor</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3623,7 +3623,7 @@ or other place where music is performed, recorded, engineered, etc.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="place.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -3632,7 +3632,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="place.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -3641,7 +3641,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="place.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3650,7 +3650,7 @@ The official name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="place.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3659,7 +3659,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="place.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -3669,7 +3669,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>address</strong></td>
+<td colspan="2" valign="top"><strong id="place.address">address</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3679,7 +3679,7 @@ standard addressing format for the country it is located in.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>area</strong></td>
+<td colspan="2" valign="top"><strong id="place.area">area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td>
 
@@ -3689,7 +3689,7 @@ which the place is located.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>coordinates</strong></td>
+<td colspan="2" valign="top"><strong id="place.coordinates">coordinates</strong></td>
 <td valign="top"><a href="#coordinates">Coordinates</a></td>
 <td>
 
@@ -3698,7 +3698,7 @@ The geographic coordinates of the place.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>lifeSpan</strong></td>
+<td colspan="2" valign="top"><strong id="place.lifespan">lifeSpan</strong></td>
 <td valign="top"><a href="#lifespan">LifeSpan</a></td>
 <td>
 
@@ -3708,7 +3708,7 @@ meaning depends on the type of entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="place.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3718,7 +3718,7 @@ function.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="place.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -3728,7 +3728,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>events</strong></td>
+<td colspan="2" valign="top"><strong id="place.events">events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
 
@@ -3747,7 +3747,7 @@ A list of events linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="place.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -3756,7 +3756,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="place.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -3775,7 +3775,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="place.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -3811,7 +3811,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="placeconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -3820,7 +3820,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="placeconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#placeedge">PlaceEdge</a>]</td>
 <td>
 
@@ -3829,7 +3829,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="placeconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#place">Place</a>]</td>
 <td>
 
@@ -3839,7 +3839,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="placeconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -3866,7 +3866,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="placeedge.node">node</strong></td>
 <td valign="top"><a href="#place">Place</a></td>
 <td>
 
@@ -3875,7 +3875,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="placeedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -3884,7 +3884,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="placeedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -3914,7 +3914,7 @@ for the entity.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>voteCount</strong></td>
+<td colspan="2" valign="top"><strong id="rating.votecount">voteCount</strong></td>
 <td valign="top"><a href="#int">Int</a>!</td>
 <td>
 
@@ -3923,7 +3923,7 @@ The number of votes that have contributed to the rating.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>value</strong></td>
+<td colspan="2" valign="top"><strong id="rating.value">value</strong></td>
 <td valign="top"><a href="#float">Float</a></td>
 <td>
 
@@ -3960,7 +3960,7 @@ or mixing.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="recording.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -3969,7 +3969,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="recording.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -3978,7 +3978,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>title</strong></td>
+<td colspan="2" valign="top"><strong id="recording.title">title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3987,7 +3987,7 @@ The official title of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="recording.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -3996,7 +3996,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="recording.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -4006,7 +4006,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artistCredit</strong> ⚠️</td>
+<td colspan="2" valign="top"><strong id="recording.artistcredit">artistCredit</strong> ⚠️</td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
 
@@ -4025,7 +4025,7 @@ and will be removed in a major release in the future. Use the equivalent
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artistCredits</strong></td>
+<td colspan="2" valign="top"><strong id="recording.artistcredits">artistCredits</strong></td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
 
@@ -4034,7 +4034,7 @@ The main credited artist(s).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>isrcs</strong></td>
+<td colspan="2" valign="top"><strong id="recording.isrcs">isrcs</strong></td>
 <td valign="top">[<a href="#isrc">ISRC</a>]</td>
 <td>
 
@@ -4044,7 +4044,7 @@ A list of [International Standard Recording Codes](https://musicbrainz.org/doc/I
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>length</strong></td>
+<td colspan="2" valign="top"><strong id="recording.length">length</strong></td>
 <td valign="top"><a href="#duration">Duration</a></td>
 <td>
 
@@ -4054,7 +4054,7 @@ from the lengths of the tracks using it.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>video</strong></td>
+<td colspan="2" valign="top"><strong id="recording.video">video</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
 
@@ -4063,7 +4063,7 @@ Whether this is a video recording.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="recording.artists">artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
 
@@ -4082,7 +4082,7 @@ A list of artists linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="recording.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -4119,7 +4119,7 @@ Filter by one or more release statuses.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="recording.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -4128,7 +4128,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="recording.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -4147,7 +4147,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>rating</strong></td>
+<td colspan="2" valign="top"><strong id="recording.rating">rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
 
@@ -4156,7 +4156,7 @@ The rating users have given to this entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="recording.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -4192,7 +4192,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="recordingconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -4201,7 +4201,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="recordingconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#recordingedge">RecordingEdge</a>]</td>
 <td>
 
@@ -4210,7 +4210,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="recordingconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#recording">Recording</a>]</td>
 <td>
 
@@ -4220,7 +4220,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="recordingconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -4247,7 +4247,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="recordingedge.node">node</strong></td>
 <td valign="top"><a href="#recording">Recording</a></td>
 <td>
 
@@ -4256,7 +4256,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="recordingedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -4265,7 +4265,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="recordingedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -4294,7 +4294,7 @@ other and to URLs outside MusicBrainz.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>target</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.target">target</strong></td>
 <td valign="top"><a href="#entity">Entity</a>!</td>
 <td>
 
@@ -4303,7 +4303,7 @@ The target entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>direction</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.direction">direction</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -4312,7 +4312,7 @@ The direction of the relationship.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>targetType</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.targettype">targetType</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -4321,7 +4321,7 @@ The type of entity on the receiving end of the relationship.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>sourceCredit</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.sourcecredit">sourceCredit</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -4331,7 +4331,7 @@ from its main (performance) name.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>targetCredit</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.targetcredit">targetCredit</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -4341,7 +4341,7 @@ from its main (performance) name.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>begin</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.begin">begin</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
 
@@ -4350,7 +4350,7 @@ The date on which the relationship became applicable.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>end</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.end">end</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
 
@@ -4359,7 +4359,7 @@ The date on which the relationship became no longer applicable.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>ended</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.ended">ended</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
 
@@ -4368,7 +4368,7 @@ Whether the relationship still applies.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>attributes</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.attributes">attributes</strong></td>
 <td valign="top">[<a href="#string">String</a>]</td>
 <td>
 
@@ -4380,7 +4380,7 @@ relationship type.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -4389,7 +4389,7 @@ The type of relationship.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="relationship.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -4416,7 +4416,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="relationshipconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -4425,7 +4425,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="relationshipconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#relationshipedge">RelationshipEdge</a>]</td>
 <td>
 
@@ -4434,7 +4434,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="relationshipconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#relationship">Relationship</a>]</td>
 <td>
 
@@ -4444,7 +4444,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="relationshipconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -4471,7 +4471,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="relationshipedge.node">node</strong></td>
 <td valign="top"><a href="#relationship">Relationship</a></td>
 <td>
 
@@ -4480,7 +4480,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="relationshipedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -4489,7 +4489,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="relationshipedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -4516,7 +4516,7 @@ Lists of entity relationships for each entity type.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>areas</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.areas">areas</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -4573,7 +4573,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.artists">artists</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -4630,7 +4630,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>events</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.events">events</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -4687,7 +4687,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>instruments</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.instruments">instruments</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -4744,7 +4744,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>labels</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.labels">labels</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -4801,7 +4801,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>places</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.places">places</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -4858,7 +4858,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>recordings</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.recordings">recordings</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -4915,7 +4915,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.releases">releases</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -4972,7 +4972,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releaseGroups</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.releasegroups">releaseGroups</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -5029,7 +5029,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>series</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.series">series</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -5086,7 +5086,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>urls</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.urls">urls</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -5143,7 +5143,7 @@ field.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>works</strong></td>
+<td colspan="2" valign="top"><strong id="relationships.works">works</strong></td>
 <td valign="top"><a href="#relationshipconnection">RelationshipConnection</a></td>
 <td>
 
@@ -5221,7 +5221,7 @@ MusicBrainz as one release.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="release.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -5230,7 +5230,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="release.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -5239,7 +5239,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>title</strong></td>
+<td colspan="2" valign="top"><strong id="release.title">title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -5248,7 +5248,7 @@ The official title of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="release.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -5257,7 +5257,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="release.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -5267,7 +5267,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artistCredit</strong> ⚠️</td>
+<td colspan="2" valign="top"><strong id="release.artistcredit">artistCredit</strong> ⚠️</td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
 
@@ -5286,7 +5286,7 @@ and will be removed in a major release in the future. Use the equivalent
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artistCredits</strong></td>
+<td colspan="2" valign="top"><strong id="release.artistcredits">artistCredits</strong></td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
 
@@ -5295,7 +5295,7 @@ The main credited artist(s).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releaseEvents</strong></td>
+<td colspan="2" valign="top"><strong id="release.releaseevents">releaseEvents</strong></td>
 <td valign="top">[<a href="#releaseevent">ReleaseEvent</a>]</td>
 <td>
 
@@ -5304,7 +5304,7 @@ The release events for this release.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>date</strong></td>
+<td colspan="2" valign="top"><strong id="release.date">date</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
 
@@ -5315,7 +5315,7 @@ distribution mechanism.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>country</strong></td>
+<td colspan="2" valign="top"><strong id="release.country">country</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -5324,7 +5324,7 @@ The country in which the release was issued.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>asin</strong></td>
+<td colspan="2" valign="top"><strong id="release.asin">asin</strong></td>
 <td valign="top"><a href="#asin">ASIN</a></td>
 <td>
 
@@ -5334,7 +5334,7 @@ of the release.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>barcode</strong></td>
+<td colspan="2" valign="top"><strong id="release.barcode">barcode</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -5346,7 +5346,7 @@ release has one. The most common types found on releases are 12-digit
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>status</strong></td>
+<td colspan="2" valign="top"><strong id="release.status">status</strong></td>
 <td valign="top"><a href="#releasestatus">ReleaseStatus</a></td>
 <td>
 
@@ -5355,7 +5355,7 @@ The status describes how “official” a release is.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>statusID</strong></td>
+<td colspan="2" valign="top"><strong id="release.statusid">statusID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -5365,7 +5365,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>packaging</strong></td>
+<td colspan="2" valign="top"><strong id="release.packaging">packaging</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -5376,7 +5376,7 @@ information.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>packagingID</strong></td>
+<td colspan="2" valign="top"><strong id="release.packagingid">packagingID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -5386,7 +5386,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>quality</strong></td>
+<td colspan="2" valign="top"><strong id="release.quality">quality</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -5397,7 +5397,7 @@ It is not a mark of how good or bad the music itself is – for that, use
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>media</strong></td>
+<td colspan="2" valign="top"><strong id="release.media">media</strong></td>
 <td valign="top">[<a href="#medium">Medium</a>]</td>
 <td>
 
@@ -5406,7 +5406,7 @@ The media on which the release was distributed.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="release.artists">artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
 
@@ -5425,7 +5425,7 @@ A list of artists linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>labels</strong></td>
+<td colspan="2" valign="top"><strong id="release.labels">labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
 
@@ -5444,7 +5444,7 @@ A list of labels linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>recordings</strong></td>
+<td colspan="2" valign="top"><strong id="release.recordings">recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
 
@@ -5463,7 +5463,7 @@ A list of recordings linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releaseGroups</strong></td>
+<td colspan="2" valign="top"><strong id="release.releasegroups">releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
 
@@ -5491,7 +5491,7 @@ Filter by one or more release group types.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="release.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -5500,7 +5500,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="release.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -5519,7 +5519,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="release.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -5555,7 +5555,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="releaseconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -5564,7 +5564,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="releaseconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#releaseedge">ReleaseEdge</a>]</td>
 <td>
 
@@ -5573,7 +5573,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="releaseconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#release">Release</a>]</td>
 <td>
 
@@ -5583,7 +5583,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="releaseconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -5610,7 +5610,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="releaseedge.node">node</strong></td>
 <td valign="top"><a href="#release">Release</a></td>
 <td>
 
@@ -5619,7 +5619,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="releaseedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -5628,7 +5628,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="releaseedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -5656,12 +5656,12 @@ a particular label, catalog number, barcode, and format.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>area</strong></td>
+<td colspan="2" valign="top"><strong id="releaseevent.area">area</strong></td>
 <td valign="top"><a href="#area">Area</a></td>
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>date</strong></td>
+<td colspan="2" valign="top"><strong id="releaseevent.date">date</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td></td>
 </tr>
@@ -5690,7 +5690,7 @@ album – it doesn’t matter how many CDs or editions/versions it had.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -5699,7 +5699,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -5708,7 +5708,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>title</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.title">title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -5717,7 +5717,7 @@ The official title of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -5726,7 +5726,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -5736,7 +5736,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artistCredit</strong> ⚠️</td>
+<td colspan="2" valign="top"><strong id="releasegroup.artistcredit">artistCredit</strong> ⚠️</td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
 
@@ -5755,7 +5755,7 @@ and will be removed in a major release in the future. Use the equivalent
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artistCredits</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.artistcredits">artistCredits</strong></td>
 <td valign="top">[<a href="#artistcredit">ArtistCredit</a>]</td>
 <td>
 
@@ -5764,7 +5764,7 @@ The main credited artist(s).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>firstReleaseDate</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.firstreleasedate">firstReleaseDate</strong></td>
 <td valign="top"><a href="#date">Date</a></td>
 <td>
 
@@ -5773,7 +5773,7 @@ The date of the earliest release in the group.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>primaryType</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.primarytype">primaryType</strong></td>
 <td valign="top"><a href="#releasegrouptype">ReleaseGroupType</a></td>
 <td>
 
@@ -5785,7 +5785,7 @@ e.g. album, single, soundtrack, compilation, etc. A release group can have a
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>primaryTypeID</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.primarytypeid">primaryTypeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -5795,7 +5795,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>secondaryTypes</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.secondarytypes">secondaryTypes</strong></td>
 <td valign="top">[<a href="#releasegrouptype">ReleaseGroupType</a>]</td>
 <td>
 
@@ -5805,7 +5805,7 @@ that apply to this release group.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>secondaryTypeIDs</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.secondarytypeids">secondaryTypeIDs</strong></td>
 <td valign="top">[<a href="#mbid">MBID</a>]</td>
 <td>
 
@@ -5815,7 +5815,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.artists">artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
 
@@ -5834,7 +5834,7 @@ A list of artists linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -5871,7 +5871,7 @@ Filter by one or more release statuses.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -5880,7 +5880,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -5899,7 +5899,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>rating</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.rating">rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
 
@@ -5908,7 +5908,7 @@ The rating users have given to this entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroup.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -5944,7 +5944,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroupconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -5953,7 +5953,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroupconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#releasegroupedge">ReleaseGroupEdge</a>]</td>
 <td>
 
@@ -5962,7 +5962,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroupconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#releasegroup">ReleaseGroup</a>]</td>
 <td>
 
@@ -5972,7 +5972,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroupconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -5999,7 +5999,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroupedge.node">node</strong></td>
 <td valign="top"><a href="#releasegroup">ReleaseGroup</a></td>
 <td>
 
@@ -6008,7 +6008,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroupedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -6017,7 +6017,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="releasegroupedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -6044,7 +6044,7 @@ A search for MusicBrainz entities using Lucene query syntax.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>areas</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.areas">areas</strong></td>
 <td valign="top"><a href="#areaconnection">AreaConnection</a></td>
 <td>
 
@@ -6073,7 +6073,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.artists">artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
 
@@ -6102,7 +6102,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>events</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.events">events</strong></td>
 <td valign="top"><a href="#eventconnection">EventConnection</a></td>
 <td>
 
@@ -6131,7 +6131,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>instruments</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.instruments">instruments</strong></td>
 <td valign="top"><a href="#instrumentconnection">InstrumentConnection</a></td>
 <td>
 
@@ -6160,7 +6160,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>labels</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.labels">labels</strong></td>
 <td valign="top"><a href="#labelconnection">LabelConnection</a></td>
 <td>
 
@@ -6189,7 +6189,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>places</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.places">places</strong></td>
 <td valign="top"><a href="#placeconnection">PlaceConnection</a></td>
 <td>
 
@@ -6218,7 +6218,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>recordings</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.recordings">recordings</strong></td>
 <td valign="top"><a href="#recordingconnection">RecordingConnection</a></td>
 <td>
 
@@ -6247,7 +6247,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releases</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.releases">releases</strong></td>
 <td valign="top"><a href="#releaseconnection">ReleaseConnection</a></td>
 <td>
 
@@ -6276,7 +6276,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>releaseGroups</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.releasegroups">releaseGroups</strong></td>
 <td valign="top"><a href="#releasegroupconnection">ReleaseGroupConnection</a></td>
 <td>
 
@@ -6305,7 +6305,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>series</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.series">series</strong></td>
 <td valign="top"><a href="#seriesconnection">SeriesConnection</a></td>
 <td>
 
@@ -6334,7 +6334,7 @@ and search fields](https://musicbrainz.org/doc/Development/XML_Web_Service/Versi
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>works</strong></td>
+<td colspan="2" valign="top"><strong id="searchquery.works">works</strong></td>
 <td valign="top"><a href="#workconnection">WorkConnection</a></td>
 <td>
 
@@ -6382,7 +6382,7 @@ theme.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="series.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -6391,7 +6391,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="series.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -6400,7 +6400,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="series.name">name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -6409,7 +6409,7 @@ The official name of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="series.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -6418,7 +6418,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="series.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -6428,7 +6428,7 @@ contains.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="series.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -6438,7 +6438,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="series.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -6447,7 +6447,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="series.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -6466,7 +6466,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="series.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -6502,7 +6502,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="seriesconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -6511,7 +6511,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="seriesconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#seriesedge">SeriesEdge</a>]</td>
 <td>
 
@@ -6520,7 +6520,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="seriesconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#series">Series</a>]</td>
 <td>
 
@@ -6530,7 +6530,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="seriesconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -6557,7 +6557,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="seriesedge.node">node</strong></td>
 <td valign="top"><a href="#series">Series</a></td>
 <td>
 
@@ -6566,7 +6566,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="seriesedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -6575,7 +6575,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="seriesedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -6604,7 +6604,7 @@ release, or recording.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="tag.name">name</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -6613,7 +6613,7 @@ The tag label.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>count</strong></td>
+<td colspan="2" valign="top"><strong id="tag.count">count</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -6639,7 +6639,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="tagconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -6648,7 +6648,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="tagconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#tagedge">TagEdge</a>]</td>
 <td>
 
@@ -6657,7 +6657,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="tagconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#tag">Tag</a>]</td>
 <td>
 
@@ -6667,7 +6667,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="tagconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -6694,7 +6694,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="tagedge.node">node</strong></td>
 <td valign="top"><a href="#tag">Tag</a></td>
 <td>
 
@@ -6703,7 +6703,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="tagedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -6712,7 +6712,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="tagedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -6741,7 +6741,7 @@ A track is the way a recording is represented on a particular
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="track.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -6750,7 +6750,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>title</strong></td>
+<td colspan="2" valign="top"><strong id="track.title">title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -6759,7 +6759,7 @@ The official title of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>position</strong></td>
+<td colspan="2" valign="top"><strong id="track.position">position</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -6769,7 +6769,7 @@ tracks from all discs).
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>number</strong></td>
+<td colspan="2" valign="top"><strong id="track.number">number</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -6779,7 +6779,7 @@ disc or side it appears on, e.g. “A1” or “B3”.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>length</strong></td>
+<td colspan="2" valign="top"><strong id="track.length">length</strong></td>
 <td valign="top"><a href="#duration">Duration</a></td>
 <td>
 
@@ -6788,7 +6788,7 @@ The length of the track.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>recording</strong></td>
+<td colspan="2" valign="top"><strong id="track.recording">recording</strong></td>
 <td valign="top"><a href="#recording">Recording</a></td>
 <td>
 
@@ -6816,7 +6816,7 @@ acquired, an entry in another database, etc.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="url.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -6825,7 +6825,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="url.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -6834,7 +6834,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>resource</strong></td>
+<td colspan="2" valign="top"><strong id="url.resource">resource</strong></td>
 <td valign="top"><a href="#urlstring">URLString</a>!</td>
 <td>
 
@@ -6843,7 +6843,7 @@ The actual URL string.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="url.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -6871,7 +6871,7 @@ more audio recordings.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="work.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -6880,7 +6880,7 @@ The ID of an object
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="work.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -6889,7 +6889,7 @@ The MBID of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>title</strong></td>
+<td colspan="2" valign="top"><strong id="work.title">title</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -6898,7 +6898,7 @@ The official title of the entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>disambiguation</strong></td>
+<td colspan="2" valign="top"><strong id="work.disambiguation">disambiguation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -6907,7 +6907,7 @@ A comment used to help distinguish identically named entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>aliases</strong></td>
+<td colspan="2" valign="top"><strong id="work.aliases">aliases</strong></td>
 <td valign="top">[<a href="#alias">Alias</a>]</td>
 <td>
 
@@ -6917,7 +6917,7 @@ alternate names or misspellings.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>iswcs</strong></td>
+<td colspan="2" valign="top"><strong id="work.iswcs">iswcs</strong></td>
 <td valign="top">[<a href="#string">String</a>]</td>
 <td>
 
@@ -6927,7 +6927,7 @@ to the work by copyright collecting agencies.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>language</strong></td>
+<td colspan="2" valign="top"><strong id="work.language">language</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -6936,7 +6936,7 @@ The language in which the work was originally written.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>type</strong></td>
+<td colspan="2" valign="top"><strong id="work.type">type</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -6945,7 +6945,7 @@ The type of work.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>typeID</strong></td>
+<td colspan="2" valign="top"><strong id="work.typeid">typeID</strong></td>
 <td valign="top"><a href="#mbid">MBID</a></td>
 <td>
 
@@ -6955,7 +6955,7 @@ field.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>artists</strong></td>
+<td colspan="2" valign="top"><strong id="work.artists">artists</strong></td>
 <td valign="top"><a href="#artistconnection">ArtistConnection</a></td>
 <td>
 
@@ -6974,7 +6974,7 @@ A list of artists linked to this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td colspan="2" valign="top"><strong id="work.relationships">relationships</strong></td>
 <td valign="top"><a href="#relationships">Relationships</a></td>
 <td>
 
@@ -6983,7 +6983,7 @@ Relationships between this entity and other entitites.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>collections</strong></td>
+<td colspan="2" valign="top"><strong id="work.collections">collections</strong></td>
 <td valign="top"><a href="#collectionconnection">CollectionConnection</a></td>
 <td>
 
@@ -7002,7 +7002,7 @@ A list of collections containing this entity.
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>rating</strong></td>
+<td colspan="2" valign="top"><strong id="work.rating">rating</strong></td>
 <td valign="top"><a href="#rating">Rating</a></td>
 <td>
 
@@ -7011,7 +7011,7 @@ The rating users have given to this entity.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tags</strong></td>
+<td colspan="2" valign="top"><strong id="work.tags">tags</strong></td>
 <td valign="top"><a href="#tagconnection">TagConnection</a></td>
 <td>
 
@@ -7047,7 +7047,7 @@ A connection to a list of items.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td colspan="2" valign="top"><strong id="workconnection.pageinfo">pageInfo</strong></td>
 <td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
 <td>
 
@@ -7056,7 +7056,7 @@ Information to aid in pagination.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>edges</strong></td>
+<td colspan="2" valign="top"><strong id="workconnection.edges">edges</strong></td>
 <td valign="top">[<a href="#workedge">WorkEdge</a>]</td>
 <td>
 
@@ -7065,7 +7065,7 @@ A list of edges.
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>nodes</strong></td>
+<td colspan="2" valign="top"><strong id="workconnection.nodes">nodes</strong></td>
 <td valign="top">[<a href="#work">Work</a>]</td>
 <td>
 
@@ -7075,7 +7075,7 @@ A list of nodes in the connection (without going through the
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td colspan="2" valign="top"><strong id="workconnection.totalcount">totalCount</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -7102,7 +7102,7 @@ An edge in a connection.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>node</strong></td>
+<td colspan="2" valign="top"><strong id="workedge.node">node</strong></td>
 <td valign="top"><a href="#work">Work</a></td>
 <td>
 
@@ -7111,7 +7111,7 @@ The item at the end of the edge
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td colspan="2" valign="top"><strong id="workedge.cursor">cursor</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -7120,7 +7120,7 @@ A cursor for use in pagination
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>score</strong></td>
+<td colspan="2" valign="top"><strong id="workedge.score">score</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
@@ -7485,7 +7485,7 @@ An entity in the MusicBrainz schema.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>mbid</strong></td>
+<td colspan="2" valign="top"><strong id="entity.mbid">mbid</strong></td>
 <td valign="top"><a href="#mbid">MBID</a>!</td>
 <td>
 
@@ -7511,7 +7511,7 @@ An object with an ID
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="node.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 

--- a/test/fixtures/no-toc.md
+++ b/test/fixtures/no-toc.md
@@ -13,7 +13,7 @@
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>getMessage</strong></td>
+<td colspan="2" valign="top"><strong id="query.getmessage">getMessage</strong></td>
 <td valign="top"><a href="#message">Message</a></td>
 <td></td>
 </tr>
@@ -37,7 +37,7 @@
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>createMessage</strong></td>
+<td colspan="2" valign="top"><strong id="mutation.createmessage">createMessage</strong></td>
 <td valign="top"><a href="#message">Message</a></td>
 <td></td>
 </tr>
@@ -47,7 +47,7 @@
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>updateMessage</strong></td>
+<td colspan="2" valign="top"><strong id="mutation.updatemessage">updateMessage</strong></td>
 <td valign="top"><a href="#message">Message</a></td>
 <td></td>
 </tr>
@@ -76,7 +76,7 @@
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>messageSent</strong></td>
+<td colspan="2" valign="top"><strong id="subscription.messagesent">messageSent</strong></td>
 <td valign="top"><a href="#message">Message</a></td>
 <td>
 
@@ -102,17 +102,17 @@ Subscribe to new messages.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="message.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>content</strong></td>
+<td colspan="2" valign="top"><strong id="message.content">content</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>author</strong></td>
+<td colspan="2" valign="top"><strong id="message.author">author</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td></td>
 </tr>
@@ -133,12 +133,12 @@ Subscribe to new messages.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>content</strong></td>
+<td colspan="2" valign="top"><strong id="messageinput.content">content</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>author</strong></td>
+<td colspan="2" valign="top"><strong id="messageinput.author">author</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td></td>
 </tr>

--- a/test/fixtures/toc-fields.md
+++ b/test/fixtures/toc-fields.md
@@ -4,12 +4,17 @@
   <summary><strong>Table of Contents</strong></summary>
 
   * [Query](#query)
+    * [getMessage](#query.getmessage)
   * [Mutation](#mutation)
+    * [createMessage](#mutation.createmessage)
+    * [updateMessage](#mutation.updatemessage)
   * [Subscription](#subscription)
   * [Objects](#objects)
     * [Message](#message)
   * [Inputs](#inputs)
     * [MessageInput](#messageinput)
+      * [content](#messageinput.content)
+      * [author](#messageinput.author)
   * [Scalars](#scalars)
     * [Boolean](#boolean)
     * [ID](#id)

--- a/test/fixtures/union-test-2.md
+++ b/test/fixtures/union-test-2.md
@@ -28,7 +28,7 @@
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>mammals</strong></td>
+<td colspan="2" valign="top"><strong id="query.mammals">mammals</strong></td>
 <td valign="top">[<a href="#mammal">Mammal</a>]</td>
 <td></td>
 </tr>
@@ -56,7 +56,7 @@
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>legs</strong></td>
+<td colspan="2" valign="top"><strong id="dog.legs">legs</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td></td>
 </tr>
@@ -78,7 +78,7 @@ abcde
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>fins</strong></td>
+<td colspan="2" valign="top"><strong id="seal.fins">fins</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td></td>
 </tr>

--- a/test/fixtures/union-test.md
+++ b/test/fixtures/union-test.md
@@ -29,7 +29,7 @@
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>party</strong></td>
+<td colspan="2" valign="top"><strong id="query.party">party</strong></td>
 <td valign="top"><a href="#party">Party</a></td>
 <td></td>
 </tr>
@@ -66,7 +66,7 @@ This is a more elaborate description
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="organization.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
@@ -75,7 +75,7 @@ Node ID
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
+<td colspan="2" valign="top"><strong id="organization.name">name</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
@@ -84,7 +84,7 @@ Name of the organization
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>email</strong></td>
+<td colspan="2" valign="top"><strong id="organization.email">email</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -93,7 +93,7 @@ Main contact email address
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>founded</strong></td>
+<td colspan="2" valign="top"><strong id="organization.founded">founded</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
@@ -102,7 +102,7 @@ Date the organization was founded
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>ceo</strong></td>
+<td colspan="2" valign="top"><strong id="organization.ceo">ceo</strong></td>
 <td valign="top"><a href="#person">Person</a></td>
 <td>
 
@@ -128,32 +128,32 @@ A human being
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>id</strong></td>
+<td colspan="2" valign="top"><strong id="person.id">id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>firstName</strong></td>
+<td colspan="2" valign="top"><strong id="person.firstname">firstName</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>lastName</strong></td>
+<td colspan="2" valign="top"><strong id="person.lastname">lastName</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>email</strong></td>
+<td colspan="2" valign="top"><strong id="person.email">email</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>age</strong></td>
+<td colspan="2" valign="top"><strong id="person.age">age</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>dob</strong></td>
+<td colspan="2" valign="top"><strong id="person.dob">dob</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td></td>
 </tr>

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -84,6 +84,19 @@ describe('renderSchema()', () => {
     const expected = await readFile('./fixtures/union-test-2.md')
     expect(printer.output).toBe(expected)
   })
+
+  it('can link individual fields in the table of contents', async () => {
+    const schema = await loadSchemaJSON(
+      path.resolve(__dirname, './fixtures/input-objects.graphql')
+    )
+    const printer = createPrinter()
+    renderSchema(schema, {
+      printer,
+      tocFieldTypes: ['Query', 'Mutation', 'MessageInput'],
+    })
+    const expected = await readFile('./fixtures/toc-fields.md')
+    expect(printer.output).toBe(expected)
+  })
 })
 
 describe('diffSchema()', () => {


### PR DESCRIPTION
This adds an `id` to each field name in a rendered type’s table, and an option for linking to fields in the Table of Contents via a nested list of fields under each type.

<img width="224" alt="Screenshot 2024-09-17 at 11 19 36 PM" src="https://github.com/user-attachments/assets/e4ddbd9e-4177-4988-a6aa-fd2ffccbd510">

`id` was used instead of `<a name>` because GitHub renders all `<a>` elements with an underline, even those without `href`. With `id` we get a semantically equivalent anchor, but rendering stays the same.

Anchor names look like `type.field`, e.g. for the type `MessageInput` with field `author`, the anchor would be `messageinput.author`, linkable via the fragment `#messageinput.author`. Note that when rendering user-supplied anchor names and IDs, GitHub prepends `user-content-` to the name (presumably to avoid conflicts with the rest of the app). For example, the resulting anchor will actually be e.g. `#user-content-type.field`. However, it appears that GitHub web app has code to still honor the original name from the Markdown document. That is, the `href` does not actually have to include the `user-content-` part, it will find and jump to the right place regardless.

The new `--toc-fields` CLI option (and equivalent `tocFieldTypes` option in `renderSchema`) can be used to render these nested links in the Table of Contents only for certain types (e.g. `--toc-fields "Query,Mutation,Subscription"`) or for all types (`--toc-fields "*"`).

Field are linkable (they always have an `id`) even if none are linked in the TOC.

Closes #84.

@fmontorsi-equinix @cyberwombat